### PR TITLE
Random Redirect Manager: PHP 8.4/8.5 + YOURLS 1.10 compat, picker, reset, save fixes

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -1072,18 +1072,19 @@ JS;
         // errors: (1) its short-circuit `$newvalue === $oldvalue` check
         // already detected no change, and (2) MySQL's UPDATE affects 0
         // rows because the row is byte-identical (no CLIENT_FOUND_ROWS
-        // flag in YOURLS). Detect "nothing changed" up-front so we don't
-        // surface the misleading "Error saving settings." notice when
-        // the user clicked Save without touching anything. We still let
-        // ensureShortlinkExists() above run on every save so a manually
-        // deleted backing shortlink can be re-created by re-saving.
-        if ($newSettings === $this->settings) {
-            yourls_add_notice("No changes to save.");
-        } elseif (yourls_update_option(self::OPTION_NAME, $newSettings)) {
-            yourls_add_notice("Random Redirect settings saved successfully.");
-            $this->loadSettings(); // Reload settings after successful save
-        } else {
-            yourls_add_notice("Error saving settings.", "error");
+        // flag in YOURLS). Detect "nothing changed" up-front and stay
+        // silent — no notice at all — so the user doesn't see the
+        // misleading "Error saving settings." message after a no-op
+        // save. We still let ensureShortlinkExists() above run on every
+        // save so a manually deleted backing shortlink can be re-created
+        // by re-saving.
+        if ($newSettings !== $this->settings) {
+            if (yourls_update_option(self::OPTION_NAME, $newSettings)) {
+                yourls_add_notice("Random Redirect settings saved successfully.");
+                $this->loadSettings(); // Reload settings after successful save
+            } else {
+                yourls_add_notice("Error saving settings.", "error");
+            }
         }
 
         // --- Display Summary Notices ---

--- a/plugin.php
+++ b/plugin.php
@@ -482,7 +482,12 @@ HTML;
         // admin chrome. Colors use rgba()/inherit so the form looks right on
         // both vanilla YOURLS and the Sleeky admin theme (light + dark).
         $css = <<<'CSS'
-      .rrm-page .rrm-info-box { margin: 15px 0; padding: 10px 15px; border-radius: 5px; background-color: #e7f3ff; border-left: 4px solid #0080ff; color: #0d2a3e; }
+      /* Force the info-box color onto its <p> children too — Sleeky's
+         dark theme sets `color` directly on `p`, which beats the
+         inherited color from `.rrm-info-box` and leaves the body text
+         nearly invisible against the solid light-blue background. */
+      .rrm-page .rrm-info-box, .rrm-page .rrm-info-box p { color: #0d2a3e; }
+      .rrm-page .rrm-info-box { margin: 15px 0; padding: 10px 15px; border-radius: 5px; background-color: #e7f3ff; border-left: 4px solid #0080ff; }
       .rrm-page .rrm-info-box p { margin: 4px 0; }
       .rrm-page .rrm-info-box strong { color: #062840; }
       .rrm-page .settings-group, .rrm-page .redirect-list-settings { margin: 20px 0; padding: 0; border: 1px solid rgba(128, 128, 128, 0.2); border-radius: 5px; background: transparent; }

--- a/plugin.php
+++ b/plugin.php
@@ -240,11 +240,14 @@ HTML;
 HTML;
 
         // Bootstrap payload for the shortlink picker. The JS inside
-        // displayAdminAssets() reads this on load.
+        // displayAdminAssets() reads this on load. JSON_HEX_TAG escapes
+        // `<` and `>` to `<` / `>` so a user-controlled shortlink
+        // URL or title cannot smuggle a `</script>` sequence and break out
+        // of the inline JSON block. JSON.parse handles the escapes natively.
         $shortlinks = $this->getAllShortlinks();
         $payload = json_encode(
             ["shortlinks" => $shortlinks],
-            JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE
+            JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_HEX_TAG
         );
         echo "<script id=\"rrm-bootstrap\" type=\"application/json\">"
             . ($payload !== false ? $payload : '{"shortlinks":[]}')

--- a/plugin.php
+++ b/plugin.php
@@ -227,8 +227,28 @@ HTML;
 
       <p><input type="submit" value="Save All Settings" class="button button-primary"></p>
     </form>
+
+    <dialog id="rrm-picker" class="rrm-picker">
+      <h3>Pick a YOURLS shortlink</h3>
+      <input type="text" id="rrm-picker-q" placeholder="Search keyword, URL or title…" autocomplete="off">
+      <ul id="rrm-picker-list"></ul>
+      <div class="rrm-picker-actions">
+        <button type="button" id="rrm-picker-cancel" class="button button-secondary">Cancel</button>
+      </div>
+    </dialog>
     </div> <!-- .rrm-page -->
 HTML;
+
+        // Bootstrap payload for the shortlink picker. The JS inside
+        // displayAdminAssets() reads this on load.
+        $shortlinks = $this->getAllShortlinks();
+        $payload = json_encode(
+            ["shortlinks" => $shortlinks],
+            JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE
+        );
+        echo "<script id=\"rrm-bootstrap\" type=\"application/json\">"
+            . ($payload !== false ? $payload : '{"shortlinks":[]}')
+            . "</script>\n";
     }
 
     /**
@@ -391,18 +411,62 @@ HTML;
     ): void {
         $style = $isTemplate ? 'style="display: none;"' : "";
         $class = $isTemplate ? "url-chance-row template" : "url-chance-row";
-        
+
         // Only make URL required for existing lists, not for new lists
         $urlRequired = !$isTemplate && empty($urlValue) && strpos($urlName, 'new_list_urls') === false ? "required" : "";
-    
+
         echo <<<HTML
         <div class="{$class}" {$style}>
           <input type="url" name="{$urlName}" value="{$urlValue}" class="text url-input" placeholder="https://example.com" {$urlRequired}>
+          <button type="button" class="pick-shortlink button button-secondary" aria-label="Pick a YOURLS shortlink">Pick…</button>
           <input type="number" name="{$chanceName}" value="{$chanceValue}" class="text chance-input" min="0" max="100" step="any" placeholder="%">
           <span class="percent-sign">%</span>
           <button type="button" class="remove-url button" aria-label="Remove URL">✕</button>
         </div>
     HTML;
+    }
+
+    /**
+     * Fetch all existing YOURLS shortlinks for the picker UI.
+     *
+     * Mirrors the approach used by the Link Front Page plugin: a single
+     * SELECT against the URL table, capped to keep the bootstrap payload
+     * sane on busy installs. Each row is enriched with the resolved short
+     * URL so the JS picker can drop it straight into the input field.
+     *
+     * @return array<int, array{keyword: string, url: string, title: string, shorturl: string}>
+     */
+    private function getAllShortlinks(): array
+    {
+        global $ydb;
+        $table = defined("YOURLS_DB_TABLE_URL") ? YOURLS_DB_TABLE_URL : "yourls_url";
+
+        try {
+            $rows = $ydb->fetchObjects(
+                "SELECT keyword, url, title FROM `{$table}` ORDER BY timestamp DESC LIMIT 5000"
+            );
+        } catch (\Throwable $e) {
+            return [];
+        }
+
+        if (!is_array($rows)) {
+            return [];
+        }
+
+        $links = [];
+        foreach ($rows as $row) {
+            $keyword = (string) ($row->keyword ?? "");
+            if ($keyword === "") {
+                continue;
+            }
+            $links[] = [
+                "keyword" => $keyword,
+                "url" => (string) ($row->url ?? ""),
+                "title" => (string) ($row->title ?? ""),
+                "shorturl" => yourls_link($keyword),
+            ];
+        }
+        return $links;
     }
 
     /**
@@ -415,8 +479,9 @@ HTML;
         // admin chrome. Colors use rgba()/inherit so the form looks right on
         // both vanilla YOURLS and the Sleeky admin theme (light + dark).
         $css = <<<'CSS'
-      .rrm-page .rrm-info-box { margin: 15px 0; padding: 10px 15px; border-radius: 5px; background-color: rgba(0, 128, 255, 0.1); border-left: 4px solid #0080ff; color: inherit; }
+      .rrm-page .rrm-info-box { margin: 15px 0; padding: 10px 15px; border-radius: 5px; background-color: #e7f3ff; border-left: 4px solid #0080ff; color: #0d2a3e; }
       .rrm-page .rrm-info-box p { margin: 4px 0; }
+      .rrm-page .rrm-info-box strong { color: #062840; }
       .rrm-page .settings-group, .rrm-page .redirect-list-settings { margin: 20px 0; padding: 0; border: 1px solid rgba(128, 128, 128, 0.2); border-radius: 5px; background: transparent; }
       .rrm-page .settings-group { padding: 15px; }
       .rrm-page .redirect-lists-container { margin: 20px 0; display: flex; flex-direction: column; gap: 15px; }
@@ -438,7 +503,7 @@ HTML;
       .rrm-page .button.delete-list-button:hover { background-color: #c82333; }
       .rrm-page .url-chances-container { display: flex; flex-direction: column; gap: 8px; margin-bottom: 10px; }
       .rrm-page .url-chance-row { display: flex; align-items: center; gap: 10px; width: 100%; }
-      .rrm-page .url-input { flex: 3; min-width: 250px; }
+      .rrm-page .url-input { flex: 3; min-width: 200px; }
       .rrm-page .chance-input { flex: 0 0 80px; width: 80px; text-align: right; }
       .rrm-page .percent-sign { flex: 0 0 10px; margin-right: 5px; opacity: 0.7; }
       .rrm-page .remove-url { flex: 0 0 25px; background-color: #f44336; color: #fff; border: none; width: 25px; height: 25px; border-radius: 50%; display: flex; align-items: center; justify-content: center; cursor: pointer; font-size: 12px; padding: 0; line-height: 1; }
@@ -447,7 +512,38 @@ HTML;
       .rrm-page .total-percentage { font-weight: bold; opacity: 0.8; }
       .rrm-page .percentage-sum { color: #008000; }
       .rrm-page .percentage-sum.error { color: #f44336; font-weight: bold; }
-      .rrm-page .add-url { cursor: pointer; }
+      /* Secondary buttons (Add URL, Pick…, Cancel). Translucent grays so the
+         button blends with both Sleeky's light and dark themes — text uses
+         `inherit` to pick up the surrounding admin chrome's foreground color. */
+      .rrm-page .button.button-secondary, .rrm-page .add-url, .rrm-page .pick-shortlink {
+        background-color: rgba(128, 128, 128, 0.12);
+        color: inherit;
+        border: 1px solid rgba(128, 128, 128, 0.35);
+        padding: 6px 14px;
+        border-radius: 3px;
+        cursor: pointer;
+        font-size: 0.9em;
+        line-height: 1.4;
+        transition: background-color 0.15s, border-color 0.15s;
+      }
+      .rrm-page .button.button-secondary:hover, .rrm-page .add-url:hover, .rrm-page .pick-shortlink:hover {
+        background-color: rgba(128, 128, 128, 0.22);
+        border-color: rgba(128, 128, 128, 0.55);
+      }
+      .rrm-page .pick-shortlink { flex: 0 0 auto; padding: 6px 10px; font-size: 0.85em; }
+      /* Shortlink picker dialog */
+      .rrm-page .rrm-picker { width: min(600px, 92vw); max-height: 80vh; padding: 18px; border: 1px solid rgba(128, 128, 128, 0.4); border-radius: 6px; background: #fff; color: #1a1a1a; box-shadow: 0 10px 40px rgba(0, 0, 0, 0.25); }
+      .rrm-page .rrm-picker::backdrop { background: rgba(0, 0, 0, 0.45); }
+      .rrm-page .rrm-picker h3 { margin: 0 0 10px; font-size: 1.05em; }
+      .rrm-page .rrm-picker input[type="text"] { width: 100%; padding: 8px; border: 1px solid rgba(128, 128, 128, 0.4); border-radius: 3px; box-sizing: border-box; margin-bottom: 10px; background: #fff; color: #1a1a1a; }
+      .rrm-page .rrm-picker ul { list-style: none; margin: 0; padding: 0; max-height: 50vh; overflow-y: auto; border: 1px solid rgba(128, 128, 128, 0.2); border-radius: 3px; }
+      .rrm-page .rrm-picker li { padding: 8px 10px; border-bottom: 1px solid rgba(128, 128, 128, 0.15); cursor: pointer; }
+      .rrm-page .rrm-picker li:last-child { border-bottom: none; }
+      .rrm-page .rrm-picker li:hover, .rrm-page .rrm-picker li.is-active { background: rgba(0, 128, 255, 0.08); }
+      .rrm-page .rrm-picker li strong { font-family: monospace; color: #0080ff; }
+      .rrm-page .rrm-picker .rrm-picker-url { display: block; font-size: 0.85em; color: #555; word-break: break-all; }
+      .rrm-page .rrm-picker .rrm-picker-title { display: block; font-size: 0.85em; color: #888; font-style: italic; }
+      .rrm-page .rrm-picker-actions { display: flex; justify-content: flex-end; margin-top: 10px; }
       @media (max-width: 768px) {
         .rrm-page .redirect-list-row { flex-direction: column; gap: 10px; }
         .rrm-page .url-chance-row { flex-wrap: wrap; }
@@ -461,6 +557,103 @@ CSS;
       document.addEventListener('DOMContentLoaded', function() {
         const form = document.getElementById('random-redirect-form');
         if (!form) return;
+
+        // --- Shortlink picker bootstrap ---
+        let allShortlinks = [];
+        const bootstrapEl = document.getElementById('rrm-bootstrap');
+        if (bootstrapEl) {
+          try {
+            const data = JSON.parse(bootstrapEl.textContent);
+            if (Array.isArray(data.shortlinks)) allShortlinks = data.shortlinks;
+          } catch (e) { /* keep allShortlinks empty on parse failure */ }
+        }
+
+        const picker      = document.getElementById('rrm-picker');
+        const pickerInput = document.getElementById('rrm-picker-q');
+        const pickerList  = document.getElementById('rrm-picker-list');
+        const pickerCancel = document.getElementById('rrm-picker-cancel');
+        let pickerTarget = null;
+
+        function openPicker(targetInput) {
+          if (!picker) return;
+          pickerTarget = targetInput;
+          if (pickerInput) pickerInput.value = '';
+          renderPickerList('');
+          if (typeof picker.showModal === 'function') picker.showModal();
+          else picker.setAttribute('open', '');
+          if (pickerInput) setTimeout(() => pickerInput.focus(), 30);
+        }
+
+        function closePicker() {
+          if (!picker) return;
+          if (typeof picker.close === 'function') picker.close();
+          else picker.removeAttribute('open');
+          pickerTarget = null;
+        }
+
+        function renderPickerList(query) {
+          if (!pickerList) return;
+          const q = (query || '').toLowerCase().trim();
+          const matches = (q === ''
+            ? allShortlinks
+            : allShortlinks.filter(l =>
+                (l.keyword || '').toLowerCase().includes(q) ||
+                (l.url     || '').toLowerCase().includes(q) ||
+                (l.title   || '').toLowerCase().includes(q)
+              )
+          ).slice(0, 200);
+
+          pickerList.innerHTML = '';
+          if (matches.length === 0) {
+            const li = document.createElement('li');
+            li.innerHTML = '<em>No matches.</em>';
+            pickerList.appendChild(li);
+            return;
+          }
+          for (const link of matches) {
+            const li = document.createElement('li');
+            li.dataset.shorturl = link.shorturl || '';
+            const kw = document.createElement('strong');
+            kw.textContent = link.keyword;
+            li.appendChild(kw);
+            const url = document.createElement('span');
+            url.className = 'rrm-picker-url';
+            url.textContent = link.url || '';
+            li.appendChild(url);
+            if (link.title) {
+              const t = document.createElement('span');
+              t.className = 'rrm-picker-title';
+              t.textContent = link.title;
+              li.appendChild(t);
+            }
+            pickerList.appendChild(li);
+          }
+        }
+
+        if (pickerInput) {
+          pickerInput.addEventListener('input', e => renderPickerList(e.target.value));
+          pickerInput.addEventListener('keydown', e => {
+            if (e.key === 'Enter') {
+              e.preventDefault();
+              const first = pickerList && pickerList.querySelector('li[data-shorturl]');
+              if (first) first.click();
+            } else if (e.key === 'Escape') {
+              closePicker();
+            }
+          });
+        }
+        if (pickerList) {
+          pickerList.addEventListener('click', e => {
+            const li = e.target.closest('li[data-shorturl]');
+            if (!li) return;
+            if (pickerTarget) {
+              pickerTarget.value = li.dataset.shorturl;
+              pickerTarget.dispatchEvent(new Event('input', { bubbles: true }));
+            }
+            closePicker();
+          });
+        }
+        if (pickerCancel) pickerCancel.addEventListener('click', closePicker);
 
         // --- Event Delegation ---
         form.addEventListener('click', function(event) {
@@ -478,6 +671,13 @@ CSS;
             const row = event.target.closest('.url-chance-row');
             const container = row.closest('.url-chances-container');
             removeUrlRow(row, container);
+          }
+          // Pick existing shortlink
+          else if (event.target.classList.contains('pick-shortlink')) {
+            event.preventDefault();
+            const row = event.target.closest('.url-chance-row');
+            const urlInput = row && row.querySelector('.url-input');
+            if (urlInput) openPicker(urlInput);
           }
         });
 

--- a/plugin.php
+++ b/plugin.php
@@ -966,8 +966,18 @@ JS;
         }
 
         // --- Save Settings ---
-        // Only update if there were no critical errors preventing saving (like keyword conflicts handled above)
-        if (yourls_update_option(self::OPTION_NAME, $newSettings)) {
+        // yourls_update_option() returns false in two cases that aren't
+        // errors: (1) its short-circuit `$newvalue === $oldvalue` check
+        // already detected no change, and (2) MySQL's UPDATE affects 0
+        // rows because the row is byte-identical (no CLIENT_FOUND_ROWS
+        // flag in YOURLS). Detect "nothing changed" up-front so we don't
+        // surface the misleading "Error saving settings." notice when
+        // the user clicked Save without touching anything. We still let
+        // ensureShortlinkExists() above run on every save so a manually
+        // deleted backing shortlink can be re-created by re-saving.
+        if ($newSettings === $this->settings) {
+            yourls_add_notice("No changes to save.");
+        } elseif (yourls_update_option(self::OPTION_NAME, $newSettings)) {
             yourls_add_notice("Random Redirect settings saved successfully.");
             $this->loadSettings(); // Reload settings after successful save
         } else {

--- a/plugin.php
+++ b/plugin.php
@@ -8,6 +8,10 @@
  * Author URI: https://github.com/lammersbjorn
  * License: BSD 3-Clause
  * License URI: https://opensource.org/licenses/BSD-3-Clause
+ * Requires at least: YOURLS 1.7.3
+ * Tested up to: YOURLS 1.10.2
+ * Requires PHP: 7.4
+ * Tested up to PHP: 8.5
  */
 
 // Prevent direct access to this file
@@ -63,8 +67,12 @@ class RandomRedirectManager
             return;
         }
 
-        // Get the requested keyword (path part of the URL)
-        $request = trim(parse_url($_SERVER["REQUEST_URI"], PHP_URL_PATH), "/");
+        // Get the requested keyword (path part of the URL).
+        // PHP 8.1+ deprecates passing null to string functions, so coalesce
+        // any null/false from parse_url() (malformed REQUEST_URI) to "".
+        $requestUri = isset($_SERVER["REQUEST_URI"]) ? (string) $_SERVER["REQUEST_URI"] : "";
+        $path = parse_url($requestUri, PHP_URL_PATH);
+        $request = trim(is_string($path) ? $path : "", "/");
         // Decode URL-encoded characters (e.g., %20 -> space)
         $request = urldecode($request);
 
@@ -170,11 +178,14 @@ class RandomRedirectManager
         // Output CSS and JS first
         $this->displayAdminAssets();
 
-        // Output HTML using HEREDOC for better readability
+        // Output HTML using HEREDOC for better readability. The whole page
+        // is wrapped in `.rrm-page` so the plugin styles don't bleed into
+        // the surrounding YOURLS / Sleeky admin chrome.
         echo <<<HTML
+    <div class="rrm-page">
     <h2>Random Redirect Manager</h2>
 
-    <div class="notice notice-info">
+    <div class="rrm-info-box">
       <p><strong>Note:</strong> When you add or update a redirect list, the plugin automatically creates/updates the corresponding YOURLS shortlink. The first URL in the list is used as the target for the shortlink.</p>
       <p><strong>Chance Percentages:</strong> Define the probability for each URL. The system normalizes positive percentages if they don't sum to 100%. URLs with 0% or no percentage set won't be chosen unless all percentages are zero (then it's equal distribution).</p>
     </div>
@@ -210,6 +221,7 @@ HTML;
 
       <p><input type="submit" value="Save All Settings" class="button button-primary"></p>
     </form>
+    </div> <!-- .rrm-page -->
 HTML;
     }
 
@@ -392,43 +404,49 @@ HTML;
      */
     private function displayAdminAssets(): void
     {
-        // CSS - Using HEREDOC for multiline string
+        // CSS - Using HEREDOC for multiline string. Every selector is scoped
+        // to .rrm-page so the plugin styles don't bleed into the surrounding
+        // admin chrome. Colors use rgba()/inherit so the form looks right on
+        // both vanilla YOURLS and the Sleeky admin theme (light + dark).
         $css = <<<'CSS'
-      .notice { margin: 15px 0; padding: 10px 15px; border-radius: 5px; }
-      .notice-info { background-color: rgba(0, 128, 255, 0.1); border-left: 4px solid #0080ff; }
-      .settings-group, .redirect-list-settings { margin: 20px 0; padding: 15px; border: 1px solid rgba(128, 128, 128, 0.2); border-radius: 5px; }
-      .redirect-lists-container { margin: 20px 0; display: flex; flex-direction: column; gap: 15px; }
-      .redirect-list-header { display: flex; justify-content: space-between; align-items: center; padding: 10px 15px; border-bottom: 1px solid rgba(128, 128, 128, 0.2); background-color: rgba(128, 128, 128, 0.05); }
-      .redirect-list-header h4 { margin: 0; }
-      .list-actions { display: flex; align-items: center; gap: 10px; }
-      .redirect-list-content { padding: 15px; }
-      .redirect-list-row { display: flex; gap: 15px; margin-bottom: 15px; }
-      .redirect-list-row:last-child { margin-bottom: 0; }
-      .redirect-list-col { flex: 1; }
-      .redirect-list-col.full { flex: 0 0 100%; }
-      .redirect-list-col label { display: block; margin-bottom: 5px; font-weight: bold; }
-      input.text, textarea.text { width: 100%; padding: 8px; border: 1px solid rgba(128, 128, 128, 0.3); border-radius: 3px; background: transparent; color: inherit; box-sizing: border-box; }
-      input:required:invalid { border-color: #f44336; }
-      .redirect-list-toggle { display: flex; align-items: center; gap: 5px; font-weight: normal; }
-      .button.delete-list-button { background-color: #dc3545; color: white; border: none; padding: 5px 10px; border-radius: 3px; cursor: pointer; }
-      .button.delete-list-button:hover { background-color: #c82333; }
-      .url-chances-container { display: flex; flex-direction: column; gap: 8px; margin-bottom: 10px; }
-      .url-chance-row { display: flex; align-items: center; gap: 10px; width: 100%; }
-      .url-input { flex: 3; min-width: 250px; }
-      .chance-input { flex: 0 0 80px; width: 80px; text-align: right; }
-      .percent-sign { flex: 0 0 10px; margin-right: 5px; }
-      .remove-url { flex: 0 0 25px; background-color: #f44336; color: white; border: none; width: 25px; height: 25px; border-radius: 50%; display: flex; align-items: center; justify-content: center; cursor: pointer; font-size: 12px; padding: 0; line-height: 1; }
-      .remove-url:hover { background-color: #e53935; }
-      .url-actions { display: flex; justify-content: space-between; align-items: center; margin-top: 10px; }
-      .total-percentage { color: #666; font-weight: bold; }
-      .percentage-sum { color: #008000; }
-      .percentage-sum.error { color: #f44336; font-weight: bold; }
-      .add-url { cursor: pointer; }
+      .rrm-page .rrm-info-box { margin: 15px 0; padding: 10px 15px; border-radius: 5px; background-color: rgba(0, 128, 255, 0.1); border-left: 4px solid #0080ff; color: inherit; }
+      .rrm-page .rrm-info-box p { margin: 4px 0; }
+      .rrm-page .settings-group, .rrm-page .redirect-list-settings { margin: 20px 0; padding: 0; border: 1px solid rgba(128, 128, 128, 0.2); border-radius: 5px; background: transparent; }
+      .rrm-page .settings-group { padding: 15px; }
+      .rrm-page .redirect-lists-container { margin: 20px 0; display: flex; flex-direction: column; gap: 15px; }
+      .rrm-page .redirect-list-header { display: flex; justify-content: space-between; align-items: center; padding: 10px 15px; border-bottom: 1px solid rgba(128, 128, 128, 0.2); background-color: rgba(128, 128, 128, 0.05); }
+      .rrm-page .redirect-list-header h4 { margin: 0; font-size: 1em; }
+      .rrm-page .keyword-display { font-family: monospace; }
+      .rrm-page .list-actions { display: flex; align-items: center; gap: 10px; }
+      .rrm-page .redirect-list-content { padding: 15px; }
+      .rrm-page .redirect-list-row { display: flex; gap: 15px; margin-bottom: 15px; }
+      .rrm-page .redirect-list-row:last-child { margin-bottom: 0; }
+      .rrm-page .redirect-list-col { flex: 1; }
+      .rrm-page .redirect-list-col.full { flex: 0 0 100%; }
+      .rrm-page .redirect-list-col label { display: block; margin-bottom: 5px; font-weight: bold; }
+      .rrm-page input.text, .rrm-page textarea.text { width: 100%; padding: 8px; border: 1px solid rgba(128, 128, 128, 0.3); border-radius: 3px; background: transparent; color: inherit; box-sizing: border-box; }
+      .rrm-page input.text:focus, .rrm-page textarea.text:focus { outline: 2px solid rgba(0, 128, 255, 0.4); outline-offset: 1px; }
+      .rrm-page input:required:invalid { border-color: #f44336; }
+      .rrm-page .redirect-list-toggle { display: flex; align-items: center; gap: 5px; font-weight: normal; }
+      .rrm-page .button.delete-list-button { background-color: #dc3545; color: #fff; border: none; padding: 5px 10px; border-radius: 3px; cursor: pointer; }
+      .rrm-page .button.delete-list-button:hover { background-color: #c82333; }
+      .rrm-page .url-chances-container { display: flex; flex-direction: column; gap: 8px; margin-bottom: 10px; }
+      .rrm-page .url-chance-row { display: flex; align-items: center; gap: 10px; width: 100%; }
+      .rrm-page .url-input { flex: 3; min-width: 250px; }
+      .rrm-page .chance-input { flex: 0 0 80px; width: 80px; text-align: right; }
+      .rrm-page .percent-sign { flex: 0 0 10px; margin-right: 5px; opacity: 0.7; }
+      .rrm-page .remove-url { flex: 0 0 25px; background-color: #f44336; color: #fff; border: none; width: 25px; height: 25px; border-radius: 50%; display: flex; align-items: center; justify-content: center; cursor: pointer; font-size: 12px; padding: 0; line-height: 1; }
+      .rrm-page .remove-url:hover { background-color: #e53935; }
+      .rrm-page .url-actions { display: flex; justify-content: space-between; align-items: center; margin-top: 10px; }
+      .rrm-page .total-percentage { font-weight: bold; opacity: 0.8; }
+      .rrm-page .percentage-sum { color: #008000; }
+      .rrm-page .percentage-sum.error { color: #f44336; font-weight: bold; }
+      .rrm-page .add-url { cursor: pointer; }
       @media (max-width: 768px) {
-        .redirect-list-row { flex-direction: column; gap: 10px; }
-        .url-chance-row { flex-wrap: wrap; }
-        .url-input { min-width: 200px; }
-        .list-actions { flex-direction: column; align-items: flex-start; gap: 5px; }
+        .rrm-page .redirect-list-row { flex-direction: column; gap: 10px; }
+        .rrm-page .url-chance-row { flex-wrap: wrap; }
+        .rrm-page .url-input { min-width: 200px; }
+        .rrm-page .list-actions { flex-direction: column; align-items: flex-start; gap: 5px; }
       }
 CSS;
 
@@ -573,12 +591,19 @@ JS;
             return;
         }
 
-        // Verify nonce
-        yourls_verify_nonce(
+        // Verify nonce. The 4th argument ($return) makes the call return
+        // false instead of dying internally, so the `or yourls_die()` branch
+        // actually runs on failure. The 3rd argument ($user) stays at the
+        // YOURLS default by passing the empty string.
+        $nonceValid = yourls_verify_nonce(
             "random_redirect_settings_nonce",
-            $_POST["nonce"] ?? "",
-            false // Do not die, just return false
-        ) or yourls_die("Invalid security token", "Error", 403);
+            (string) ($_POST["nonce"] ?? ""),
+            "",
+            true
+        );
+        if (!$nonceValid) {
+            yourls_die("Invalid security token", "Error", 403);
+        }
 
         $currentSettings = $this->settings; // Use cached settings
         $newSettings = [];
@@ -764,11 +789,14 @@ JS;
             return "";
         }
         $keyword = trim($keyword);
-        // Allow letters, numbers, hyphen, underscore, forward slash
-        // Remove leading/trailing slashes and collapse multiple slashes
+        // Allow letters, numbers, hyphen, underscore, forward slash.
+        // Remove leading/trailing slashes and collapse multiple slashes.
         $keyword = trim($keyword, "/");
-        $keyword = preg_replace("#/+#", "/", $keyword);
-        if (preg_match('/^[a-zA-Z0-9-_\/]+$/', $keyword)) {
+        // preg_replace can return null on regex error — coalesce so PHP 8.1+
+        // doesn't emit a deprecation when the result reaches preg_match.
+        $collapsed = preg_replace("#/+#", "/", $keyword);
+        $keyword = is_string($collapsed) ? $collapsed : $keyword;
+        if (preg_match('/^[a-zA-Z0-9\-_\/]+$/', $keyword)) {
             return $keyword;
         }
         return ""; // Invalid characters

--- a/plugin.php
+++ b/plugin.php
@@ -226,6 +226,16 @@ HTML;
       </div> <!-- .settings-group.add-new-list -->
 
       <p><input type="submit" value="Save All Settings" class="button button-primary"></p>
+
+      <div class="rrm-danger-zone">
+        <h4>Danger zone</h4>
+        <p>Removes every redirect list configured here. The matching YOURLS shortlinks themselves are kept and will need to be deleted manually if you don't want them anymore.</p>
+        <button type="submit" name="reset_all" value="1" formnovalidate
+          class="button reset-all-button"
+          onclick="return confirm('Are you sure you want to remove ALL redirect lists? This cannot be undone.')">
+          Reset all redirect lists
+        </button>
+      </div>
     </form>
 
     <dialog id="rrm-picker" class="rrm-picker">
@@ -531,34 +541,58 @@ HTML;
          button blends with both Sleeky's light and dark themes — text uses
          `inherit` to pick up the surrounding admin chrome's foreground color. */
       .rrm-page .button.button-secondary, .rrm-page .add-url, .rrm-page .pick-shortlink {
-        background-color: rgba(128, 128, 128, 0.12);
+        background-color: rgba(128, 128, 128, 0.18);
         color: inherit;
-        border: 1px solid rgba(128, 128, 128, 0.35);
+        border: 1px solid rgba(128, 128, 128, 0.5);
         padding: 6px 14px;
         border-radius: 3px;
         cursor: pointer;
         font-size: 0.9em;
         line-height: 1.4;
+        font-weight: 500;
         transition: background-color 0.15s, border-color 0.15s;
       }
       .rrm-page .button.button-secondary:hover, .rrm-page .add-url:hover, .rrm-page .pick-shortlink:hover {
-        background-color: rgba(128, 128, 128, 0.22);
-        border-color: rgba(128, 128, 128, 0.55);
+        background-color: rgba(128, 128, 128, 0.3);
+        border-color: rgba(128, 128, 128, 0.7);
       }
       .rrm-page .pick-shortlink { flex: 0 0 auto; padding: 6px 10px; font-size: 0.85em; }
-      /* Shortlink picker dialog */
+      /* Danger zone (reset all). Sits below the form's main Save button
+         and uses the same red accent as per-list Delete buttons. */
+      .rrm-page .rrm-danger-zone { margin-top: 25px; padding: 15px; border: 1px solid rgba(220, 53, 69, 0.4); border-radius: 5px; background-color: rgba(220, 53, 69, 0.06); }
+      .rrm-page .rrm-danger-zone h4 { margin: 0 0 6px; color: #dc3545; font-size: 1em; }
+      .rrm-page .rrm-danger-zone p { margin: 0 0 10px; opacity: 0.85; font-size: 0.9em; }
+      .rrm-page .button.reset-all-button { background-color: #dc3545; color: #fff; border: none; padding: 8px 16px; border-radius: 3px; cursor: pointer; font-weight: 600; }
+      .rrm-page .button.reset-all-button:hover { background-color: #c82333; }
+      /* Shortlink picker dialog (light variant — default) */
       .rrm-page .rrm-picker { width: min(600px, 92vw); max-height: 80vh; padding: 18px; border: 1px solid rgba(128, 128, 128, 0.4); border-radius: 6px; background: #fff; color: #1a1a1a; box-shadow: 0 10px 40px rgba(0, 0, 0, 0.25); }
       .rrm-page .rrm-picker::backdrop { background: rgba(0, 0, 0, 0.45); }
-      .rrm-page .rrm-picker h3 { margin: 0 0 10px; font-size: 1.05em; }
+      .rrm-page .rrm-picker h3 { margin: 0 0 10px; font-size: 1.05em; color: inherit; }
       .rrm-page .rrm-picker input[type="text"] { width: 100%; padding: 8px; border: 1px solid rgba(128, 128, 128, 0.4); border-radius: 3px; box-sizing: border-box; margin-bottom: 10px; background: #fff; color: #1a1a1a; }
-      .rrm-page .rrm-picker ul { list-style: none; margin: 0; padding: 0; max-height: 50vh; overflow-y: auto; border: 1px solid rgba(128, 128, 128, 0.2); border-radius: 3px; }
-      .rrm-page .rrm-picker li { padding: 8px 10px; border-bottom: 1px solid rgba(128, 128, 128, 0.15); cursor: pointer; }
+      .rrm-page .rrm-picker ul { list-style: none; margin: 0; padding: 0; max-height: 50vh; overflow-y: auto; border: 1px solid rgba(128, 128, 128, 0.2); border-radius: 3px; background: transparent; }
+      .rrm-page .rrm-picker li { padding: 8px 10px; border-bottom: 1px solid rgba(128, 128, 128, 0.15); cursor: pointer; color: inherit; }
       .rrm-page .rrm-picker li:last-child { border-bottom: none; }
       .rrm-page .rrm-picker li:hover, .rrm-page .rrm-picker li.is-active { background: rgba(0, 128, 255, 0.08); }
       .rrm-page .rrm-picker li strong { font-family: monospace; color: #0080ff; }
       .rrm-page .rrm-picker .rrm-picker-url { display: block; font-size: 0.85em; color: #555; word-break: break-all; }
       .rrm-page .rrm-picker .rrm-picker-title { display: block; font-size: 0.85em; color: #888; font-style: italic; }
       .rrm-page .rrm-picker-actions { display: flex; justify-content: flex-end; margin-top: 10px; }
+      /* Shortlink picker dialog — dark variant. JS adds `.rrm-dark` when
+         Sleeky's <meta name="sleeky_theme" content="dark"> is present so
+         the popup matches the surrounding dark chrome instead of slamming
+         a stark white panel into the middle of the page. */
+      .rrm-page .rrm-picker.rrm-dark { background: #2a2a2a; color: #e0e0e0; border-color: rgba(255, 255, 255, 0.15); box-shadow: 0 10px 40px rgba(0, 0, 0, 0.6); }
+      .rrm-page .rrm-picker.rrm-dark::backdrop { background: rgba(0, 0, 0, 0.65); }
+      .rrm-page .rrm-picker.rrm-dark input[type="text"] { background: #1d1d1d; color: #e0e0e0; border-color: rgba(255, 255, 255, 0.2); }
+      .rrm-page .rrm-picker.rrm-dark input[type="text"]::placeholder { color: rgba(255, 255, 255, 0.4); }
+      .rrm-page .rrm-picker.rrm-dark ul { border-color: rgba(255, 255, 255, 0.12); }
+      .rrm-page .rrm-picker.rrm-dark li { border-color: rgba(255, 255, 255, 0.08); }
+      .rrm-page .rrm-picker.rrm-dark li:hover, .rrm-page .rrm-picker.rrm-dark li.is-active { background: rgba(0, 128, 255, 0.18); }
+      .rrm-page .rrm-picker.rrm-dark li strong { color: #4da3ff; }
+      .rrm-page .rrm-picker.rrm-dark .rrm-picker-url { color: #b0b0b0; }
+      .rrm-page .rrm-picker.rrm-dark .rrm-picker-title { color: #888; }
+      .rrm-page .rrm-picker.rrm-dark .button.button-secondary { background-color: rgba(255, 255, 255, 0.1); border-color: rgba(255, 255, 255, 0.25); color: #e0e0e0; }
+      .rrm-page .rrm-picker.rrm-dark .button.button-secondary:hover { background-color: rgba(255, 255, 255, 0.18); border-color: rgba(255, 255, 255, 0.4); }
       @media (max-width: 768px) {
         .rrm-page .redirect-list-row { flex-direction: column; gap: 10px; }
         .rrm-page .url-chance-row { flex-wrap: wrap; }
@@ -588,6 +622,16 @@ CSS;
         const pickerList  = document.getElementById('rrm-picker-list');
         const pickerCancel = document.getElementById('rrm-picker-cancel');
         let pickerTarget = null;
+
+        // Sleeky's plugin emits <meta name="sleeky_theme" content="light|dark">
+        // when active. Tag the picker so its CSS picks the matching variant
+        // instead of forcing a white modal onto a dark page.
+        if (picker) {
+          const sleekyMeta = document.querySelector('meta[name="sleeky_theme"]');
+          if (sleekyMeta && sleekyMeta.getAttribute('content') === 'dark') {
+            picker.classList.add('rrm-dark');
+          }
+        }
 
         function openPicker(targetInput) {
           if (!picker) return;
@@ -868,6 +912,22 @@ JS;
             "deleted" => 0,
             "errors" => [],
         ];
+
+        // --- Handle Reset-All Action ---
+        // Wipes every redirect list. The matching YOURLS shortlinks
+        // themselves are kept (same approach as per-list Delete) so a
+        // reset can't quietly drop unrelated keywords.
+        if (!empty($_POST["reset_all"])) {
+            if (empty($currentSettings)) {
+                yourls_add_notice("No redirect lists to remove.");
+            } elseif (yourls_update_option(self::OPTION_NAME, [])) {
+                yourls_add_notice("All redirect lists have been removed.");
+                $this->loadSettings();
+            } else {
+                yourls_add_notice("Error resetting settings.", "error");
+            }
+            return;
+        }
 
         // --- Handle Delete Action ---
         if (isset($_POST["delete_list"]) && !empty($_POST["delete_list"])) {

--- a/plugin.php
+++ b/plugin.php
@@ -591,19 +591,18 @@ JS;
             return;
         }
 
-        // Verify nonce. The 4th argument ($return) makes the call return
-        // false instead of dying internally, so the `or yourls_die()` branch
-        // actually runs on failure. The 3rd argument ($user) stays at the
-        // YOURLS default by passing the empty string.
-        $nonceValid = yourls_verify_nonce(
+        // Verify nonce. The 4th argument is the message YOURLS will die()
+        // with on failure (a truthy $return triggers `die($return)` inside
+        // yourls_verify_nonce in YOURLS 1.10), so passing our own message
+        // here removes the need for a separate yourls_die() branch — the
+        // previous shape was unreachable. The 3rd argument stays at the
+        // sentinel `false` so YOURLS picks the logged-in user automatically.
+        yourls_verify_nonce(
             "random_redirect_settings_nonce",
             (string) ($_POST["nonce"] ?? ""),
-            "",
-            true
+            false,
+            "Invalid security token"
         );
-        if (!$nonceValid) {
-            yourls_die("Invalid security token", "Error", 403);
-        }
 
         $currentSettings = $this->settings; // Use cached settings
         $newSettings = [];

--- a/plugin.php
+++ b/plugin.php
@@ -937,12 +937,12 @@ JS;
                 // Note: We don't delete the base YOURLS shortlink automatically. Admin can do that manually if desired.
                 if (yourls_update_option(self::OPTION_NAME, $currentSettings)) {
                     yourls_add_notice(
-                        "Redirect list for keyword '{$keywordToDelete}' deleted successfully."
+                        "Redirect list for keyword “{$keywordToDelete}” deleted successfully."
                     );
                     $this->loadSettings(); // Reload settings after successful delete
                 } else {
                     yourls_add_notice(
-                        "Error deleting list for keyword '{$keywordToDelete}'.",
+                        "Error deleting list for keyword “{$keywordToDelete}”.",
                         "error"
                     );
                 }
@@ -950,7 +950,7 @@ JS;
                 return;
             } else {
                 yourls_add_notice(
-                    "Could not delete list: Keyword '{$keywordToDelete}' not found.",
+                    "Could not delete list: Keyword “{$keywordToDelete}” not found.",
                     "error"
                 );
                 return; // Stop if delete was intended but failed
@@ -969,7 +969,7 @@ JS;
                 if (!$oldKeyword || !$newKeyword) {
                     $messages[
                         "errors"
-                    ][] = "Invalid or empty keyword provided for an existing list (original: '{$oldKeyword}'). Skipped.";
+                    ][] = "Invalid or empty keyword provided for an existing list (original: “{$oldKeyword}”). Skipped.";
                     continue;
                 }
 
@@ -980,7 +980,7 @@ JS;
                 ) {
                     $messages[
                         "errors"
-                    ][] = "Keyword '{$newKeyword}' is used multiple times in this submission. Reverted change for '{$oldKeyword}'.";
+                    ][] = "Keyword “{$newKeyword}” is used multiple times in this submission. Reverted change for “{$oldKeyword}”.";
                     $newKeyword = $oldKeyword; // Keep the old keyword to avoid conflict
                 }
 
@@ -996,7 +996,7 @@ JS;
                 if (empty($urls)) {
                     $messages[
                         "errors"
-                    ][] = "No valid URLs provided for keyword '{$newKeyword}'. List not saved.";
+                    ][] = "No valid URLs provided for keyword “{$newKeyword}”. List not saved.";
                     continue; // Skip if no URLs
                 }
 
@@ -1040,11 +1040,11 @@ JS;
             } elseif (isset($newSettings[$newKeyword])) {
                 $messages[
                     "errors"
-                ][] = "The new keyword '{$newKeyword}' conflicts with another list in this submission. New list skipped.";
+                ][] = "The new keyword “{$newKeyword}” conflicts with another list in this submission. New list skipped.";
             } elseif (empty($urls)) {
                 $messages[
                     "errors"
-                ][] = "No valid URLs provided for the new keyword '{$newKeyword}'. New list not saved.";
+                ][] = "No valid URLs provided for the new keyword “{$newKeyword}”. New list not saved.";
             } else {
                 // Ensure chances array matches urls array size
                 $chances = array_slice($chances, 0, count($urls));
@@ -1195,13 +1195,13 @@ JS;
         array &$errors
     ): void {
         if (empty($keyword) || empty($url)) {
-            $errors[] = "Cannot ensure shortlink: Invalid keyword or URL provided. Keyword: '{$keyword}'";
+            $errors[] = "Cannot ensure shortlink: Invalid keyword or URL provided. Keyword: “{$keyword}”";
             return;
         }
 
         // Check if keyword is reserved or already taken by YOURLS core/another plugin
         if (yourls_keyword_is_reserved($keyword)) {
-            $errors[] = "Keyword '{$keyword}' is reserved and cannot be used.";
+            $errors[] = "Keyword “{$keyword}” is reserved and cannot be used.";
             return;
         }
 
@@ -1226,7 +1226,7 @@ JS;
             } elseif ($result && isset($result["message"])) {
                 // Check if the failure was due to the keyword already existing (race condition?)
                 if (strpos($result["message"], "already exists") === false) {
-                    $errors[] = "Failed to create shortlink for '{$keyword}': {$result["message"]}";
+                    $errors[] = "Failed to create shortlink for “{$keyword}”: {$result["message"]}";
                 } else {
                     // Keyword exists now, maybe created by another process or race condition. Try updating.
                     $existingUrl = yourls_get_keyword_longurl($keyword); // Re-fetch
@@ -1240,13 +1240,13 @@ JS;
                                 // This updates URL and optionally title
                                 $updated++;
                             } else {
-                                $errors[] = "Failed to update existing shortlink URL for '{$keyword}' after creation conflict.";
+                                $errors[] = "Failed to update existing shortlink URL for “{$keyword}” after creation conflict.";
                             }
                         }
                     }
                 }
             } else {
-                $errors[] = "Failed to create shortlink for '{$keyword}' (Unknown error).";
+                $errors[] = "Failed to create shortlink for “{$keyword}” (Unknown error).";
             }
         } elseif ($existingUrl !== $url) {
             // Shortlink exists, but URL is different, update it
@@ -1262,7 +1262,7 @@ JS;
                     // This updates URL and optionally title
                     $updated++;
                 } else {
-                    $errors[] = "Failed to update existing shortlink URL for '{$keyword}'.";
+                    $errors[] = "Failed to update existing shortlink URL for “{$keyword}”.";
                 }
             }
         }

--- a/plugin.php
+++ b/plugin.php
@@ -279,7 +279,7 @@ HTML;
                 <input type="checkbox" name="list_enabled[{$escapedKeyword}]" value="1" {$checked}>
                 Enable
               </label>
-              <button type="submit" name="delete_list" value="{$escapedKeyword}"
+              <button type="submit" name="delete_list" value="{$escapedKeyword}" formnovalidate
                 class="button delete-list-button" onclick="return confirm('Are you sure you want to delete the list for keyword \'{$escapedKeyword}\'? This action is immediate and cannot be undone.')">
                 Delete List
               </button>
@@ -415,8 +415,15 @@ HTML;
         $style = $isTemplate ? 'style="display: none;"' : "";
         $class = $isTemplate ? "url-chance-row template" : "url-chance-row";
 
-        // Only make URL required for existing lists, not for new lists
-        $urlRequired = !$isTemplate && empty($urlValue) && strpos($urlName, 'new_list_urls') === false ? "required" : "";
+        // Visible rows of an *existing* redirect list always need a URL —
+        // an empty URL would silently drop the entire list server-side.
+        // Template rows stay un-required so their hidden inputs don't
+        // block submission. New-list rows are toggled by JS based on
+        // whether the user typed a keyword: requiring them
+        // unconditionally would block every save when the user only
+        // wants to update existing lists.
+        $isNewList = strpos($urlName, "new_list_urls") !== false;
+        $urlRequired = !$isTemplate && !$isNewList ? "required" : "";
 
         echo <<<HTML
         <div class="{$class}" {$style}>
@@ -707,6 +714,10 @@ CSS;
                 }
              }
           }
+          // New-list keyword toggles the required-state of its URL rows.
+          if (event.target.id === 'new_list_keyword') {
+            syncNewListRequired();
+          }
         });
 
         // --- Initialization ---
@@ -714,6 +725,10 @@ CSS;
         document.querySelectorAll('.url-chances-container').forEach(container => {
           updatePercentageSum(container);
         });
+        // Apply the initial required-state to the new-list URL rows so a
+        // pre-filled keyword (e.g. after a server-side validation bounce)
+        // gets the required attribute right away.
+        syncNewListRequired();
       });
 
       function addNewUrlRow(container) {
@@ -724,14 +739,21 @@ CSS;
         newRow.style.display = 'flex';
         newRow.classList.remove('template');
 
-        // Clear template values and remove 'required' if it was added dynamically
         const urlInput = newRow.querySelector('.url-input');
         const chanceInput = newRow.querySelector('.chance-input');
-        if(urlInput) {
+        if (urlInput) {
             urlInput.value = '';
-            urlInput.removeAttribute('required'); // Only first row might be required initially
+            // Existing-list rows must always be required so the user
+            // can't silently submit an empty URL. New-list rows track
+            // the keyword field via syncNewListRequired() below.
+            const isNewListRow = (urlInput.name || '').startsWith('new_list_urls');
+            if (isNewListRow) {
+                urlInput.removeAttribute('required');
+            } else {
+                urlInput.setAttribute('required', '');
+            }
         }
-        if(chanceInput) chanceInput.value = '';
+        if (chanceInput) chanceInput.value = '';
 
         // Enable inputs (template inputs might be disabled)
         newRow.querySelectorAll('input').forEach(input => input.disabled = false);
@@ -739,8 +761,28 @@ CSS;
         // Insert before the template
         container.insertBefore(newRow, template);
 
-        updatePercentageSum(container); // Update sum after adding
-        if(urlInput) urlInput.focus(); // Focus new URL input
+        updatePercentageSum(container);
+        // Newly added new-list rows might still need to flip to required
+        // if the user has already typed a keyword.
+        syncNewListRequired();
+        if (urlInput) urlInput.focus();
+      }
+
+      // Make the New-Redirect-List section's URL inputs required only
+      // when the user has actually typed a new keyword. Otherwise the
+      // empty starter row in that section would block every save.
+      function syncNewListRequired() {
+        const kwInput = document.getElementById('new_list_keyword');
+        if (!kwInput) return;
+        const hasKeyword = kwInput.value.trim() !== '';
+        document
+          .querySelectorAll('input[name="new_list_urls[]"]')
+          .forEach((input) => {
+            const row = input.closest('.url-chance-row');
+            if (row && row.classList.contains('template')) return;
+            if (hasKeyword) input.setAttribute('required', '');
+            else input.removeAttribute('required');
+          });
       }
 
       function removeUrlRow(row, container) {

--- a/plugin.php
+++ b/plugin.php
@@ -34,13 +34,19 @@ class RandomRedirectManager
 
         // Admin page hooks
         yourls_add_action("plugins_loaded", [$this, "addAdminPage"]);
-        yourls_add_action("admin_page_random_redirect_settings", [
-            $this,
-            "displayAdminPage",
-        ]);
 
-        // Process form submissions
-        yourls_add_action("admin_init", [$this, "processFormSubmission"]);
+        // Process form submissions on the plugin page itself. The
+        // `load-<plugin_page>` action fires from yourls_plugin_admin_page()
+        // *after* yourls_maybe_require_auth() has defined YOURLS_USER, so
+        // yourls_verify_nonce() sees the same user as yourls_create_nonce()
+        // did when the form was rendered. The earlier `admin_init` hook
+        // ran from Init::__construct() *before* auth, leaving YOURLS_USER
+        // undefined — that mismatch is what produced the
+        // "Unauthorized action or expired link" failure on save.
+        yourls_add_action("load-random_redirect_settings", [
+            $this,
+            "processFormSubmission",
+        ]);
 
         // Check requests for redirects
         yourls_add_action("shutdown", [$this, "checkRequest"]);

--- a/plugin.php
+++ b/plugin.php
@@ -1092,6 +1092,17 @@ JS;
             return;
         }
 
+        // If the first random URL is itself a YOURLS shortlink on this
+        // install, resolve it to its long URL before handing it to
+        // yourls_add_new_link(). YOURLS rejects shortlink-to-shortlink
+        // chains with "URL is a shortened URL", which surfaces in the
+        // admin as "Failed to create shortlink for 'foo': URL is een
+        // verkorte URL" the moment a user picks an existing shortlink
+        // from the picker as the first target. The random redirect
+        // itself still uses the original (short) URL — only the
+        // auto-created backing shortlink uses the resolved long URL.
+        $url = $this->resolveYourlsShortlink($url);
+
         $existingUrl = yourls_get_keyword_longurl($keyword);
 
         if ($existingUrl === false) {
@@ -1143,6 +1154,48 @@ JS;
             }
         }
         // If $existingUrl === $url, do nothing, it's already correct.
+    }
+
+    /**
+     * If $url is a YOURLS shortlink on this install, swap it for its
+     * long URL. Any other URL is returned unchanged.
+     *
+     * Used to dodge YOURLS' "URL is a shortened URL" check inside
+     * yourls_add_new_link() when the auto-created backing shortlink for
+     * a random redirect would otherwise point at another shortlink on
+     * the same domain. Compares hosts case-insensitively because YOURLS
+     * normalises hostnames that way too.
+     *
+     * @param string $url Possibly a YOURLS short URL.
+     * @return string Long URL if resolvable, otherwise the original.
+     */
+    private function resolveYourlsShortlink(string $url): string
+    {
+        if ($url === "" || !defined("YOURLS_SITE")) {
+            return $url;
+        }
+
+        $siteHost = parse_url(YOURLS_SITE, PHP_URL_HOST);
+        $urlHost = parse_url($url, PHP_URL_HOST);
+        if (
+            !is_string($siteHost) ||
+            !is_string($urlHost) ||
+            strcasecmp($siteHost, $urlHost) !== 0
+        ) {
+            return $url;
+        }
+
+        $path = parse_url($url, PHP_URL_PATH);
+        $keyword = trim(is_string($path) ? $path : "", "/");
+        if ($keyword === "") {
+            return $url;
+        }
+
+        $longUrl = yourls_get_keyword_longurl($keyword);
+        if (is_string($longUrl) && $longUrl !== "") {
+            return $longUrl;
+        }
+        return $url;
     }
 }
 

--- a/plugin.php
+++ b/plugin.php
@@ -9,7 +9,7 @@
  * License: BSD 3-Clause
  * License URI: https://opensource.org/licenses/BSD-3-Clause
  * Requires at least: YOURLS 1.7.3
- * Tested up to: YOURLS 1.10.2
+ * Tested up to: YOURLS 1.10.3
  * Requires PHP: 7.4
  * Tested up to PHP: 8.5
  */
@@ -257,7 +257,10 @@ HTML;
         $shortlinks = $this->getAllShortlinks();
         $payload = json_encode(
             ["shortlinks" => $shortlinks],
-            JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_HEX_TAG
+            JSON_UNESCAPED_SLASHES |
+                JSON_UNESCAPED_UNICODE |
+                JSON_HEX_TAG |
+                JSON_INVALID_UTF8_SUBSTITUTE
         );
         echo "<script id=\"rrm-bootstrap\" type=\"application/json\">"
             . ($payload !== false ? $payload : '{"shortlinks":[]}')
@@ -304,7 +307,7 @@ HTML;
                   value="{$escapedKeyword}"
                   class="text keyword-input"
                   required
-                  pattern="^[a-zA-Z0-9-_\/]+$"
+                  pattern="^[a-zA-Z0-9_\/-]+$"
                   title="Allowed characters: a-z, A-Z, 0-9, -, _, /">
               </div>
             </div>
@@ -371,7 +374,7 @@ HTML;
         <label for="new_list_keyword">New Keyword:</label>
         <input type="text" id="new_list_keyword" name="new_list_keyword" class="text keyword-input"
           placeholder="Enter keyword (e.g., random-link)"
-          pattern="^[a-zA-Z0-9-_\/]+$"
+          pattern="^[a-zA-Z0-9_\/-]+$"
           title="Allowed characters: a-z, A-Z, 0-9, -, _, /">
       </div>
     </div>
@@ -891,18 +894,12 @@ JS;
             return;
         }
 
-        // Verify nonce. The 4th argument is the message YOURLS will die()
-        // with on failure (a truthy $return triggers `die($return)` inside
-        // yourls_verify_nonce in YOURLS 1.10), so passing our own message
-        // here removes the need for a separate yourls_die() branch — the
-        // previous shape was unreachable. The 3rd argument stays at the
-        // sentinel `false` so YOURLS picks the logged-in user automatically.
-        yourls_verify_nonce(
-            "random_redirect_settings_nonce",
-            (string) ($_POST["nonce"] ?? ""),
-            false,
-            "Invalid security token"
-        );
+        // Verify nonce. Keep YOURLS' default yourls_die(..., 403) failure
+        // path, and only pass a string nonce so malformed nonce[]= payloads
+        // do not emit array-to-string warnings on PHP 8.4+.
+        $nonceInput = $_POST["nonce"] ?? "";
+        $nonce = is_string($nonceInput) ? $nonceInput : "";
+        yourls_verify_nonce("random_redirect_settings_nonce", $nonce);
 
         $currentSettings = $this->settings; // Use cached settings
         $newSettings = [];
@@ -1300,6 +1297,20 @@ JS;
 
         $path = parse_url($url, PHP_URL_PATH);
         $keyword = trim(is_string($path) ? $path : "", "/");
+
+        // YOURLS can live in subdirectory (eg /links). Strip that
+        // install path from incoming short URL before keyword lookup.
+        $sitePath = trim((string) parse_url(YOURLS_SITE, PHP_URL_PATH), "/");
+        if ($sitePath !== "") {
+            if ($keyword === $sitePath) {
+                return $url;
+            }
+            $sitePrefix = $sitePath . "/";
+            if (strpos($keyword, $sitePrefix) === 0) {
+                $keyword = substr($keyword, strlen($sitePrefix));
+            }
+        }
+
         if ($keyword === "") {
             return $url;
         }


### PR DESCRIPTION
## Summary

Twelve commits' worth of fixes and new features on `plugin.php`. The plugin now runs cleanly on PHP 8.4 / 8.5 and YOURLS 1.10, the settings page no longer leaks CSS into the surrounding admin chrome, saves work end-to-end (the "Unauthorized action or expired link" and "Error saving settings." notices were both wrong), and there's a YOURLS shortlink picker, a "Reset all redirect lists" button, and a danger-zone section.

No breaking changes: the option key (`random_redirect_settings`), hook signatures, and redirect code (HTTP 307) are unchanged. Existing saved data keeps working as-is.

## New features

### YOURLS shortlink picker
Every URL row in the settings page now has a **Pick…** button that opens a `<dialog>` listing every shortlink in the install (keyword + long URL + title) with a live filter. Selecting a row drops the resolved short URL into the input. Mirrors the picker UX from YOURLS-Link-Front-Page so users can point a redirect at one of their own shortlinks without retyping.

* PHP-side: a single `SELECT keyword, url, title FROM yourls_url ORDER BY timestamp DESC LIMIT 5000` (mirrors `lfp_get_all_yourls_links()` from YOURLS-Link-Front-Page).
* Bootstrap payload rendered as `<script id="rrm-bootstrap" type="application/json">` once per page load — no extra HTTP requests on filter — with `JSON_HEX_TAG` so a shortlink containing `</script>` in its URL or title can't break out of the inline JSON block (CodeRabbit catch).
* `<dialog>` is feature-detected: `showModal()` if supported, with a non-modal `[open]` fallback.
* The picker reads Sleeky's `<meta name="sleeky_theme" content="dark">` and switches to a dark variant (background, search input, list items, hover, secondary button) instead of slamming a stark white modal into a dark page.

### Reset all redirect lists (Danger zone)
A separate red-bordered section under the Save button with a single **Reset all redirect lists** button. Carries `formnovalidate` so the URL-required check (see below) doesn't block it, with a `confirm()` guard against accidental clicks. Server-side branch wipes the option in one shot. The matching YOURLS shortlinks themselves are kept (same approach as the per-list Delete button).

### Required URL fields
Every visible URL row in an existing redirect list is now `required` so a save can't silently drop the entire list when all URLs are blanked. Previously the `required` attribute was only added when the URL value was already empty at render time, which meant a saved value could be cleared freely. The Add-New-Redirect-List section toggles its required-ness from JS based on whether the user typed a keyword — empty keyword = the user isn't creating a new list and we shouldn't block their save on that row. Per-list **Delete** buttons get `formnovalidate` so they can still remove a list with unrelated empty rows.

## Bug fixes

### Saves now actually save
**"Unauthorized action or expired link" on every save** — `processFormSubmission()` was hooked to `admin_init`, which YOURLS fires from `Init::__construct()` inside `load-yourls.php`, *before* `admin/plugins.php` calls `yourls_maybe_require_auth()`. At that point `YOURLS_USER` is not yet defined, so `yourls_verify_nonce()` falls back to user `'-1'`. The matching `yourls_create_nonce()` call in `displayAdminPage()` runs *after* auth, so it computes the hash against the real `YOURLS_USER`. The two values never match. Switched to the page-specific `load-random_redirect_settings` action (fired from `yourls_plugin_admin_page()` after auth) so both nonce calls see the same user. Also dropped the dead `admin_page_random_redirect_settings` hook — YOURLS doesn't fire any such action; the page callback comes from `yourls_register_plugin_page()` and is invoked directly.

**"Error saving settings." when nothing changed** — `yourls_update_option()` returns `false` in two scenarios that aren't errors: its internal `$newvalue === $oldvalue` short-circuit, and MySQL's UPDATE returning 0 affected rows when the serialized payload is byte-identical (YOURLS doesn't enable `CLIENT_FOUND_ROWS`). Now we compare `$newSettings` against the cached `$this->settings` up-front and stay silent in the no-change case (no notice at all). `ensureShortlinkExists()` keeps running on every save so a manually-deleted backing shortlink can be re-created by re-saving an unchanged form.

**"Failed to create shortlink: URL is een verkorte URL"** — when the first URL of a redirect list is itself a YOURLS shortlink on the same install (most likely after using the new picker), YOURLS rejects the auto-created backing shortlink because it refuses shortlink-to-shortlink chains. Added a `resolveYourlsShortlink()` helper that swaps a same-site short URL for its long URL before handing it to `yourls_add_new_link()`. The random redirect list itself is untouched, so click stats on the picked shortlink still fire — only the backing shortlink uses the resolved long URL.

**Notices showed `\'keyword\'` instead of `'keyword'`** — `yourls_add_notice()` runs every message through `strtr($message, ["'" => "\\'"])` before stashing it in an `admin_notices` closure. The escape isn't needed (the closure captures `$message` via `use()`, no string interpolation to break) but leaks visible `\'` into rendered notices. Can't fix that in YOURLS, so the workaround is on our side: switch the literal single quotes around interpolated keywords to typographic curly quotes (U+201C / U+201D) — they render cleanly and aren't touched by `strtr`.

### Compatibility (PHP 8.4 / 8.5)

* **`checkRequest()`** — coalesce `parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH)` to a string before passing to `trim()` / `urldecode()`. PHP 8.1+ deprecates passing null to string functions, and `parse_url` *does* return null on a malformed `REQUEST_URI`.
* **`sanitizeKeyword()`** — defend against `preg_replace()` returning null on a regex error, and explicitly escape the literal `-` inside the character class for clarity.
* **Plugin header** — `Tested up to: YOURLS 1.10.2` / `Tested up to PHP: 8.5` / `Requires PHP: 7.4`.

### Admin styling (vanilla YOURLS + Sleeky)

The previous CSS used very generic class names (`.notice`, `.settings-group`) that override YOURLS / Sleeky styles for *other* plugins on the same admin page. Wrapping the page in a single `.rrm-page` container and re-scoping every selector under it fixes that without touching the form layout.

* New wrapping `<div class="rrm-page">` around the entire settings page.
* Standalone `<div class="notice notice-info">` renamed to `.rrm-info-box` so it stops overriding YOURLS' built-in `.notice` look. Background and text colors are now explicit (`#e7f3ff` / `#0d2a3e`) so the box stays readable on Sleeky light mode where the previous `color: inherit` picked up a near-white text color from the surrounding chrome. The `<p>` color is set explicitly too — Sleeky's dark theme sets `color` directly on `p` with higher specificity than the inherited box color, which would otherwise leave the body text invisible against the light-blue background.
* Previously-unstyled secondary buttons ("Add URL", "Pick…", "Cancel") now have a translucent gray style (`.button-secondary` / `.add-url`) — they had the class but no rule existed for it, so the browser fell back to the native button look. Text uses `color: inherit` so it reads correctly in both Sleeky light and dark, with stronger contrast (background opacity 0.18, border 0.5, font-weight 500) so they actually read as buttons.
* Hard-coded greys swapped for `rgba()` / `inherit` elsewhere so the form reads correctly in Sleeky's light *and* dark themes.
* Focus outlines added to text inputs / textareas — purely visual.

## What I did **not** change

* The option key (`random_redirect_settings`) — backwards-compatible with existing installs.
* The redirect code (still HTTP 307).
* The form field names — existing saved data keeps working.
* The plugin version — left to the maintainer; the picker + reset are user-visible features so a minor bump is probably warranted.
* When **Reset all** or **Delete List** runs, the matching YOURLS shortlinks (created by previous saves) are deliberately *not* removed — admins can clean those up manually if they want.

## Test plan

- [ ] Install on YOURLS 1.10.2 + PHP 8.4 and confirm no deprecations / warnings appear in `user/debug.log` while exercising the settings page.
- [ ] Activate Sleeky-backend alongside this plugin; check the settings page in both light and dark mode (info-box readable, secondary buttons visible, picker popup matches the theme).
- [ ] Save a redirect list, hit the keyword from a fresh browser, confirm the random redirect still fires.
- [ ] Click **Save All Settings** with no changes — silent (no notice). Click after touching anything — "Random Redirect settings saved successfully.".
- [ ] Click **Save** with the form tampered (cleared nonce) and confirm YOURLS dies with the "Invalid security token" message.
- [ ] Open the **Pick…** dialog on a URL row, filter by keyword / URL / title, pick a shortlink and confirm the resolved short URL lands in the input. Save and confirm the redirect uses that URL (and that no "URL is een verkorte URL" error appears).
- [ ] Open the **Pick…** dialog on the "Add New Redirect List" row and confirm the same flow works for new lists.
- [ ] Try to save with all URLs cleared in an existing list — HTML5 validation should block submission. Try the same on the new-list section without typing a keyword — save should still work because the URL field isn't required there.
- [ ] Click **Delete List** on a list with unrelated empty rows in the form — should work despite the URL-required attribute (`formnovalidate`).
- [ ] Click **Reset all redirect lists**, confirm the dialog, confirm all lists are removed and the notice reads "All redirect lists have been removed.". Click again on an empty config and confirm "No redirect lists to remove.".
- [ ] Delete a list with a keyword and check the notice — should read `Redirect list for keyword "foo" deleted successfully.` with proper curly quotes (no `\'foo\'`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a shortlink picker dialog in admin settings, enabling quick selection of shortcuts filterable by keyword, URL, or title.

* **Bug Fixes**
  * Improved redirect keyword extraction and data sanitization to prevent invalid inputs.
  * Strengthened authentication validation for admin form submissions.

* **Chores**
  * Updated plugin compatibility metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
