### PR TITLE
ci: add lightweight PHP test suite

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,100 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '**.php'
+      - 'tests/**'
+      - '.github/workflows/tests.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - '**.php'
+      - 'tests/**'
+      - '.github/workflows/tests.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  php:
+    name: PHP ${{ matrix.php }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - php: '8.1'
+            phpunit: '10'
+          - php: '8.4'
+            phpunit: '11'
+
+    services:
+      mariadb:
+        image: mariadb:11
+        ports:
+          - 3306:3306
+        env:
+          MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: 'true'
+        options: >-
+          --health-cmd="mariadb-admin ping -h localhost -u root --silent"
+          --health-interval=10s --health-timeout=5s --health-retries=10
+
+    steps:
+      - name: Checkout plugin
+        uses: actions/checkout@v6
+
+      - name: Set up PHP ${{ matrix.php }}
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: mbstring, curl, zip, dom, simplexml, intl, pdo_mysql, mysqli
+          tools: phpunit:${{ matrix.phpunit }}
+
+      - name: Lint PHP
+        run: find . -path './test-suite' -prune -o -name '*.php' -print0 | xargs -0 -n1 php -l
+
+      - name: Install YOURLS test suite
+        run: |
+          git clone --depth 1 https://github.com/YOURLS/YOURLS-test-suite-for-plugins test-suite
+          bash test-suite/src/install-test-suite.sh yourls_tests root '' 127.0.0.1 1.10.3
+
+      - name: Run PHPUnit
+        run: phpunit -c tests/phpunit.xml
+
+  package:
+    name: Package smoke
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout plugin
+        uses: actions/checkout@v6
+
+      - name: Build install zip
+        run: |
+          set -euo pipefail
+          rm -rf dist staging
+          mkdir -p dist staging/Random-Redirect-Manager
+          rsync -a \
+            --exclude='.git/' \
+            --exclude='.gitignore' \
+            --exclude='.github/' \
+            --exclude='tests/' \
+            --exclude='test-suite/' \
+            --exclude='dist/' \
+            --exclude='staging/' \
+            ./ staging/Random-Redirect-Manager/
+          (cd staging && zip -rq "$GITHUB_WORKSPACE/dist/YOURLS-Random-Redirect-Manager.zip" Random-Redirect-Manager)
+
+      - name: Verify install zip contents
+        run: |
+          set -euo pipefail
+          unzip -l dist/YOURLS-Random-Redirect-Manager.zip
+          unzip -l dist/YOURLS-Random-Redirect-Manager.zip | grep -q 'Random-Redirect-Manager/plugin.php'
+          if unzip -l dist/YOURLS-Random-Redirect-Manager.zip | grep -Eq 'Random-Redirect-Manager/(\.github|tests|test-suite)/'; then
+            echo "::error::Install zip contains development files"
+            exit 1
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+# Editor / OS noise
+.DS_Store
+Thumbs.db
+.vscode/
+.idea/
+*.swp
+*.bak
+
+# Test and build artifacts
+test-suite/
+dist/
+staging/

--- a/tests/RandomRedirectManagerTest.php
+++ b/tests/RandomRedirectManagerTest.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+
+final class RandomRedirectManagerTest extends PHPUnit\Framework\TestCase
+{
+    private const OPTION_NAME = 'random_redirect_settings';
+
+    public function test_plugin_class_is_loaded(): void
+    {
+        $this->assertTrue(class_exists('RandomRedirectManager'));
+    }
+
+    /**
+     * @dataProvider registeredHooksProvider
+     */
+    public function test_plugin_registers_expected_hooks(string $hook, string $method): void
+    {
+        $this->assertHookHasPluginMethod($hook, $method);
+    }
+
+    public static function registeredHooksProvider(): array
+    {
+        return [
+            'admin page registration' => ['plugins_loaded', 'addAdminPage'],
+            'form submission' => ['load-random_redirect_settings', 'processFormSubmission'],
+            'request interception' => ['shutdown', 'checkRequest'],
+        ];
+    }
+
+    public function test_settings_are_loaded_as_array(): void
+    {
+        $settings = $this->readPrivateProperty($this->pluginInstance(), 'settings');
+
+        $this->assertIsArray($settings);
+    }
+
+    /**
+     * @dataProvider keywordProvider
+     */
+    public function test_keyword_sanitizer_matches_form_pattern($input, string $expected): void
+    {
+        $method = $this->privateMethod('sanitizeKeyword');
+
+        $this->assertSame($expected, $method->invoke($this->pluginInstance(), $input));
+    }
+
+    public static function keywordProvider(): array
+    {
+        return [
+            'simple' => ['promo', 'promo'],
+            'nested' => ['/folder//promo/', 'folder/promo'],
+            'underscore and hyphen' => ['sale_2026-test', 'sale_2026-test'],
+            'colon rejected' => ['foo:bar', ''],
+            'array rejected' => [['promo'], ''],
+        ];
+    }
+
+    public function test_url_sanitizer_rejects_invalid_and_reindexes(): void
+    {
+        $method = $this->privateMethod('sanitizeUrlArray');
+
+        $this->assertSame(
+            ['https://example.com/a', 'https://example.com/b'],
+            $method->invoke($this->pluginInstance(), [
+                'https://example.com/a',
+                'not a url',
+                '',
+                'https://example.com/b',
+            ])
+        );
+    }
+
+    public function test_chance_sanitizer_rejects_negative_and_invalid_values(): void
+    {
+        $method = $this->privateMethod('sanitizeChanceArray');
+
+        $this->assertSame([25.5, 0.0, 0.0, 0.0], $method->invoke($this->pluginInstance(), [
+            '25.5',
+            '-1',
+            'nope',
+            '',
+        ]));
+    }
+
+    public function test_same_site_shortlink_resolver_leaves_unmatched_urls_unchanged(): void
+    {
+        $method = $this->privateMethod('resolveYourlsShortlink');
+
+        $this->assertSame(
+            'https://example.com/outside',
+            $method->invoke($this->pluginInstance(), 'https://example.com/outside')
+        );
+    }
+
+    public function test_weighted_random_url_returns_one_configured_url(): void
+    {
+        $method = $this->privateMethod('getWeightedRandomUrl');
+        $urls = ['https://example.com/a', 'https://example.com/b'];
+
+        $this->assertContains($method->invoke($this->pluginInstance(), $urls, [0, 0]), $urls);
+        $this->assertSame('https://example.com/b', $method->invoke($this->pluginInstance(), $urls, [0, 100]));
+    }
+
+    private function assertHookHasPluginMethod(string $hook, string $method): void
+    {
+        $filters = yourls_get_filters($hook);
+        $this->assertIsArray($filters, "Hook {$hook} is not registered.");
+
+        foreach ($filters as $priorityBucket) {
+            if (!is_array($priorityBucket)) {
+                continue;
+            }
+            foreach ($priorityBucket as $entry) {
+                $callback = $entry['function'] ?? null;
+                if (is_array($callback) && ($callback[0] ?? null) instanceof RandomRedirectManager && ($callback[1] ?? null) === $method) {
+                    $this->assertSame(1, $entry['accepted_args'] ?? null);
+                    return;
+                }
+            }
+        }
+
+        $this->fail("RandomRedirectManager::{$method} is not registered on {$hook}.");
+    }
+
+    private function pluginInstance(): RandomRedirectManager
+    {
+        $filters = yourls_get_filters('shutdown');
+        $this->assertIsArray($filters);
+
+        foreach ($filters as $priorityBucket) {
+            if (!is_array($priorityBucket)) {
+                continue;
+            }
+            foreach ($priorityBucket as $entry) {
+                $callback = $entry['function'] ?? null;
+                if (is_array($callback) && ($callback[0] ?? null) instanceof RandomRedirectManager) {
+                    return $callback[0];
+                }
+            }
+        }
+
+        $this->fail('RandomRedirectManager instance was not found in YOURLS hooks.');
+    }
+
+    private function privateMethod(string $method): ReflectionMethod
+    {
+        $reflectionMethod = new ReflectionMethod('RandomRedirectManager', $method);
+        $reflectionMethod->setAccessible(true);
+
+        return $reflectionMethod;
+    }
+
+    private function readPrivateProperty(RandomRedirectManager $plugin, string $property)
+    {
+        $reflectionProperty = new ReflectionProperty($plugin, $property);
+        $reflectionProperty->setAccessible(true);
+
+        return $reflectionProperty->getValue($plugin);
+    }
+}

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+    colors="true"
+    bootstrap="../test-suite/src/bootstrap.php">
+    <testsuites>
+        <testsuite name="Random Redirect Manager">
+            <directory suffix="Test.php">./</directory>
+        </testsuite>
+    </testsuites>
+    <php>
+        <const name="PHPUNIT_TESTSUITE" value="true"/>
+        <request name="username" value="yourls"/>
+        <request name="password" value="secret-ci-test"/>
+        <server name="SERVER_SOFTWARE" value="GITHUB_ACTIONS"/>
+        <server name="HTTP_USER_AGENT" value="GitHub Actions PHPUnit"/>
+        <server name="HTTP_HOST" value="ci.example.com"/>
+        <server name="HTTP_CLIENT_IP" value="10.10.10.1"/>
+        <request name="format" value="simple"/>
+    </php>
+</phpunit>


### PR DESCRIPTION
## Summary
- add a lightweight GitHub Actions test workflow without Playwright, browser e2e, Docker app stacks, or Sleeky
- run PHP lint plus focused PHPUnit against the official YOURLS plugin test suite on YOURLS 1.10.3
- add package smoke coverage to ensure the install zip contains plugin files and excludes dev/test files

## Test coverage
- plugin class loads through YOURLS plugin activation
- expected YOURLS hooks are registered, including load-random_redirect_settings after #4
- settings cache is an array
- keyword, URL, and chance sanitizers cover accepted/rejected values
- resolver leaves non-site URLs unchanged
- weighted redirect picker returns configured URLs and honors 100% weight

## Verification
- php -l plugin.php
- php -l tests/RandomRedirectManagerTest.php
- local package zip smoke check

Full PHPUnit is intended to run in CI because this machine does not have mysqladmin/phpunit installed locally.