### PR TITLE
docs: update compatibility notes and license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,28 +1,21 @@
-BSD 3-Clause License
+MIT License
 
-Copyright (c) 2025, Bjorn Lammers
+Copyright (c) 2025 Bjorn Lammers
 
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-1. Redistributions of source code must retain the above copyright notice, this
-   list of conditions and the following disclaimer.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-2. Redistributions in binary form must reproduce the above copyright notice,
-   this list of conditions and the following disclaimer in the documentation
-   and/or other materials provided with the distribution.
-
-3. Neither the name of the copyright holder nor the names of its
-   contributors may be used to endorse or promote products derived from
-   this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -12,10 +12,16 @@ Listed in [![Listed in Awesome YOURLS!](https://img.shields.io/badge/Awesome-YOU
 - User-friendly admin interface with percentage calculation
 - Enable/disable redirect lists as needed
 
+## Compatibility
+
+- YOURLS: requires 1.7.3+, tested up to 1.10.3
+- PHP: requires 7.4+, tested up to 8.5
+- Uses fallback edit calls when newer YOURLS helper functions are unavailable.
+
 ## Installation
 
 1. Download the plugin
-2. Place the plugin folder in your `user/plugins` directory
+2. Place the plugin folder in your `user/plugins` directory as `Random-Redirect-Manager`
 3. Activate the plugin in the YOURLS admin interface
 
 ## Usage
@@ -28,6 +34,33 @@ Listed in [![Listed in Awesome YOURLS!](https://img.shields.io/badge/Awesome-YOU
 3. Save your settings
 
 When users visit your shortlink with the specified keyword, they'll be randomly redirected to one of the destination URLs based on your configured probabilities.
+
+## Configuration Details
+
+- Keywords may contain letters, numbers, `-`, `_`, and `/`.
+- Reserved YOURLS keywords are rejected.
+- Each redirect list needs at least one valid URL.
+- Positive chance percentages are normalized automatically; they do not need to total exactly 100.
+- If every chance is `0` or empty, the plugin falls back to equal random selection.
+- Resetting lists does not delete the underlying YOURLS shortlinks automatically.
+
+## Testing
+
+Run the lightweight PHPUnit suite:
+
+```bash
+phpunit -c tests/phpunit.xml
+```
+
+For plugin changes, also run:
+
+```bash
+php -l plugin.php
+```
+
+## License
+
+MIT. See [LICENSE](LICENSE).
 
 ## Example Use Cases
 

--- a/plugin.php
+++ b/plugin.php
@@ -6,8 +6,8 @@
  * Version: 3.2
  * Author: Bjorn Lammers
  * Author URI: https://github.com/lammersbjorn
- * License: BSD 3-Clause
- * License URI: https://opensource.org/licenses/BSD-3-Clause
+ * License: MIT
+ * License URI: https://opensource.org/licenses/MIT
  * Requires at least: YOURLS 1.7.3
  * Tested up to: YOURLS 1.10.3
  * Requires PHP: 7.4
@@ -1228,7 +1228,10 @@ JS;
                     // Keyword exists now, maybe created by another process or race condition. Try updating.
                     $existingUrl = yourls_get_keyword_longurl($keyword); // Re-fetch
                     if ($existingUrl !== false && $existingUrl !== $url) {
-                        if (yourls_edit_link_url($keyword, $url)) {
+                        if (
+                            function_exists("yourls_edit_link_url") &&
+                            yourls_edit_link_url($keyword, $url)
+                        ) {
                             // Use specific function if available (YOURLS 1.7.3+)
                             $updated++;
                         } else {


### PR DESCRIPTION
## Summary
- switch repository license from BSD 3-Clause to MIT
- align plugin header license metadata with LICENSE
- add concise README compatibility, configuration, and testing notes
- guard yourls_edit_link_url() so older YOURLS installs can use the fallback path

## Verification
- php -l plugin.php
- git diff --check
- phpunit not run locally: phpunit command not installed