### PR TITLE
dev: add local YOURLS Docker harness

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -82,6 +82,8 @@ jobs:
             --exclude='.git/' \
             --exclude='.gitignore' \
             --exclude='.github/' \
+            --exclude='dev/' \
+            --exclude='scripts/' \
             --exclude='tests/' \
             --exclude='test-suite/' \
             --exclude='dist/' \
@@ -94,7 +96,7 @@ jobs:
           set -euo pipefail
           unzip -l dist/YOURLS-Random-Redirect-Manager.zip
           unzip -l dist/YOURLS-Random-Redirect-Manager.zip | grep -q 'Random-Redirect-Manager/plugin.php'
-          if unzip -l dist/YOURLS-Random-Redirect-Manager.zip | grep -Eq 'Random-Redirect-Manager/(\.github|tests|test-suite)/'; then
+          if unzip -l dist/YOURLS-Random-Redirect-Manager.zip | grep -Eq 'Random-Redirect-Manager/(\.github|dev|scripts|tests|test-suite)/'; then
             echo "::error::Install zip contains development files"
             exit 1
           fi

--- a/README.md
+++ b/README.md
@@ -52,6 +52,31 @@ php -l includes/bootstrap.php
 php -l includes/class-random-redirect-manager.php
 ```
 
+## Local YOURLS Dev
+
+Start a disposable YOURLS instance with this plugin mounted read-only:
+
+```bash
+./scripts/dev-yourls up
+```
+
+Defaults:
+
+- URL: `http://localhost:8088/admin/`
+- Login: `admin` / `adminpass`
+- YOURLS image: `yourls:latest`
+- Database: private Docker Compose MariaDB volume
+
+The script installs YOURLS if needed, activates this plugin, seeds a few GitHub shortlinks, and creates a sample weighted redirect list at `http://localhost:8088/randomrepos`.
+
+Useful commands:
+
+```bash
+./scripts/dev-yourls logs
+./scripts/dev-yourls down
+./scripts/dev-yourls reset
+```
+
 ## License
 
 MIT. See [LICENSE](LICENSE).

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -1,0 +1,39 @@
+services:
+  db:
+    image: ${YOURLS_DB_IMAGE:-mariadb:11}
+    environment:
+      MARIADB_DATABASE: ${YOURLS_DB_NAME:-yourls}
+      MARIADB_USER: ${YOURLS_DB_USER:-yourls}
+      MARIADB_PASSWORD: ${YOURLS_DB_PASS:-yourls}
+      MARIADB_ROOT_PASSWORD: ${YOURLS_DB_ROOT_PASS:-yourls-root}
+    volumes:
+      - db-data:/var/lib/mysql
+    tmpfs:
+      - /tmp
+    healthcheck:
+      test: ["CMD", "mariadb-admin", "ping", "-h", "localhost", "-u", "root", "-p${YOURLS_DB_ROOT_PASS:-yourls-root}"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+
+  yourls:
+    image: ${YOURLS_IMAGE:-yourls:latest}
+    depends_on:
+      db:
+        condition: service_healthy
+    init: true
+    environment:
+      YOURLS_DB_HOST: db
+      YOURLS_DB_USER: ${YOURLS_DB_USER:-yourls}
+      YOURLS_DB_PASS: ${YOURLS_DB_PASS:-yourls}
+      YOURLS_DB_NAME: ${YOURLS_DB_NAME:-yourls}
+      YOURLS_SITE: ${YOURLS_SITE:-http://localhost:8088}
+      YOURLS_USER: ${YOURLS_USER:-admin}
+      YOURLS_PASS: ${YOURLS_PASS:-adminpass}
+    ports:
+      - "${YOURLS_PORT:-8088}:8080"
+    volumes:
+      - ../:/var/www/html/user/plugins/Random-Redirect-Manager:ro
+
+volumes:
+  db-data:

--- a/scripts/dev-yourls
+++ b/scripts/dev-yourls
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+COMPOSE_FILE="$ROOT_DIR/dev/docker-compose.yml"
+PROJECT_NAME="${COMPOSE_PROJECT_NAME:-yourls-rrm-dev}"
+YOURLS_PORT="${YOURLS_PORT:-8088}"
+YOURLS_SITE="${YOURLS_SITE:-http://localhost:${YOURLS_PORT}}"
+YOURLS_USER="${YOURLS_USER:-admin}"
+YOURLS_PASS="${YOURLS_PASS:-adminpass}"
+PLUGIN_PATH='Random-Redirect-Manager/plugin.php'
+
+compose() {
+  COMPOSE_PROJECT_NAME="$PROJECT_NAME" YOURLS_PORT="$YOURLS_PORT" YOURLS_SITE="$YOURLS_SITE" docker compose -f "$COMPOSE_FILE" "$@"
+}
+
+wait_for_http() {
+  local url="$1"
+  local tries=60
+  until curl -fsS "$url" >/dev/null 2>&1; do
+    tries=$((tries - 1))
+    if [ "$tries" -le 0 ]; then
+      echo "Timed out waiting for $url" >&2
+      return 1
+    fi
+    sleep 2
+  done
+}
+
+install_yourls() {
+  wait_for_http "$YOURLS_SITE/admin/install.php"
+  curl -fsS -X POST -d 'install=Install+YOURLS' "$YOURLS_SITE/admin/install.php" >/dev/null || true
+}
+
+mysql() {
+  compose exec -T db mariadb -u"${YOURLS_DB_USER:-yourls}" -p"${YOURLS_DB_PASS:-yourls}" "${YOURLS_DB_NAME:-yourls}" "$@"
+}
+
+activate_plugin() {
+  local serialized
+  serialized="$(compose exec -T yourls php -r 'echo serialize(["'"$PLUGIN_PATH"'"]);')"
+  mysql -e "UPDATE yourls_options SET option_value='${serialized}' WHERE option_name='active_plugins';"
+}
+
+seed_link() {
+  local keyword="$1"
+  local url="$2"
+  curl -fsS --get "$YOURLS_SITE/yourls-api.php" \
+    --data-urlencode "username=$YOURLS_USER" \
+    --data-urlencode "password=$YOURLS_PASS" \
+    --data-urlencode 'action=shorturl' \
+    --data-urlencode 'format=json' \
+    --data-urlencode "keyword=$keyword" \
+    --data-urlencode "url=$url" >/dev/null || true
+}
+
+seed_links() {
+  seed_link repo-awin https://github.com/lammersbjorn/YOURLS-Awin
+  seed_link repo-random https://github.com/lammersbjorn/YOURLS-Random-Redirect-Manager
+  seed_link repo-yourls https://github.com/YOURLS/YOURLS
+  seed_link repo-awesome-yourls https://github.com/YOURLS/awesome-yourls
+}
+
+seed_random_redirect_settings() {
+  local serialized
+  serialized="$(compose exec -T yourls php -r 'echo serialize([
+    "randomrepos" => [
+      "enabled" => true,
+      "urls" => [
+        "https://github.com/lammersbjorn/YOURLS-Awin",
+        "https://github.com/lammersbjorn/YOURLS-Random-Redirect-Manager",
+        "https://github.com/YOURLS/YOURLS",
+      ],
+      "chances" => [40.0, 40.0, 20.0],
+    ],
+  ]);')"
+  mysql -e "INSERT INTO yourls_options (option_name, option_value) VALUES ('random_redirect_settings', '${serialized}') ON DUPLICATE KEY UPDATE option_value=VALUES(option_value);"
+  seed_link randomrepos https://example.com/random-repos-placeholder
+}
+
+start() {
+  compose up -d
+  install_yourls
+  activate_plugin
+  seed_links
+  seed_random_redirect_settings
+  echo "YOURLS ready: $YOURLS_SITE/admin/"
+  echo "Login: $YOURLS_USER / $YOURLS_PASS"
+  echo "Sample random redirect: $YOURLS_SITE/randomrepos"
+}
+
+case "${1:-up}" in
+  up|start)
+    start
+    ;;
+  stop)
+    compose stop
+    ;;
+  down)
+    compose down
+    ;;
+  reset)
+    compose down -v
+    start
+    ;;
+  logs)
+    compose logs -f "${2:-yourls}"
+    ;;
+  ps|status)
+    compose ps
+    ;;
+  *)
+    echo "Usage: $0 [up|start|stop|down|reset|logs|ps]" >&2
+    exit 2
+    ;;
+esac


### PR DESCRIPTION
## Summary
- add Docker Compose setup for latest YOURLS with this plugin mounted read-only
- add ./scripts/dev-yourls helper for up/down/reset/logs
- auto-install YOURLS, activate Random Redirect Manager, seed GitHub test links, and add a sample weighted redirect list
- document local URL, credentials, and commands
- exclude dev/ and scripts/ from install package smoke

## Defaults
- URL: http://localhost:8088/admin/
- Login: admin / adminpass
- YOURLS image: yourls:latest
- Sample redirect: http://localhost:8088/randomrepos

## Verification
- bash -n scripts/dev-yourls
- docker compose -f dev/docker-compose.yml config
- git diff --check
- local package zip smoke excludes dev/ and scripts/
- smoke run with YOURLS_PORT=8092 ./scripts/dev-yourls reset
- curl http://localhost:8092/randomrepos returns 307 to one of the configured GitHub repos