### PR TITLE
ci: support release note input

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,10 @@ on:
         options:
           - minor
           - major
+      release_notes:
+        description: Optional release notes. Leave blank to auto-generate.
+        required: false
+        type: string
   push:
     branches: [main]
 
@@ -91,14 +95,34 @@ jobs:
           (cd staging && zip -rq "$GITHUB_WORKSPACE/dist/${ZIP_NAME}" "${PLUGIN_DIR}")
           unzip -l "dist/${ZIP_NAME}"
 
+      - name: Prepare release notes
+        id: release_notes
+        env:
+          RELEASE_NOTES: ${{ inputs.release_notes }}
+        run: |
+          set -euo pipefail
+          if [ -n "$RELEASE_NOTES" ]; then
+            printf '%s\n' "$RELEASE_NOTES" > release-notes.md
+            echo "mode=manual" >> "$GITHUB_OUTPUT"
+          else
+            echo "mode=generated" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Create GitHub release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release create "${{ steps.version.outputs.tag }}" \
-            "dist/${ZIP_NAME}" \
-            --title "${{ steps.version.outputs.tag }}" \
-            --notes "Stable release ${{ steps.version.outputs.tag }}."
+          if [ "${{ steps.release_notes.outputs.mode }}" = "manual" ]; then
+            gh release create "${{ steps.version.outputs.tag }}" \
+              "dist/${ZIP_NAME}" \
+              --title "${{ steps.version.outputs.tag }}" \
+              --notes-file release-notes.md
+          else
+            gh release create "${{ steps.version.outputs.tag }}" \
+              "dist/${ZIP_NAME}" \
+              --title "${{ steps.version.outputs.tag }}" \
+              --generate-notes
+          fi
 
   alpha:
     name: Alpha release
@@ -140,4 +164,5 @@ jobs:
             --target "$GITHUB_SHA" \
             --prerelease \
             --title "Alpha ${short_sha}" \
-            --notes "Automatic alpha release for ${GITHUB_SHA}."
+            --notes "Automatic alpha release for ${GITHUB_SHA}." \
+            --generate-notes

--- a/README.md
+++ b/README.md
@@ -85,7 +85,20 @@ MIT. See [LICENSE](LICENSE).
 
 GitHub Actions includes release automation in `.github/workflows/release.yml`.
 
-- **Stable release:** run the **Release** workflow manually and choose `minor` or `major`. The workflow bumps `plugin.php` version, commits it to `main`, tags `vX.Y.0`, builds an install zip, and creates a GitHub Release.
-- **Alpha release:** every non-bot push to `main` creates a prerelease tagged `alpha-<run>-<attempt>-<sha>` with an install zip.
+- **Stable release:** run the **Release** workflow manually and choose `minor` or `major`. You can provide release notes in the workflow input, or leave it blank for GitHub generated notes. The workflow bumps `plugin.php` version, commits it to `main`, tags `vX.Y.0`, builds an install zip, and creates a GitHub Release.
+- **Alpha release:** every non-bot push to `main` creates a prerelease tagged `alpha-<run>-<attempt>-<sha>` with an install zip and generated notes.
 
 Release zips exclude development-only files such as `.github/`, `dev/`, `scripts/`, `tests/`, and `test-suite/`.
+
+Suggested release notes for the current v4 line:
+
+```markdown
+## YOURLS Random Redirect Manager
+
+### Changed
+- Split the YOURLS plugin bootstrap from runtime code.
+- Moved admin CSS and JavaScript into `assets/`.
+- Preserved existing `random_redirect_settings` compatibility.
+- Added local Docker-based YOURLS development setup with a seeded sample redirect.
+- Added install zip packaging through release automation.
+```


### PR DESCRIPTION
## Summary
- add optional release_notes input to the manual Release workflow
- use provided notes via --notes-file when present
- fall back to GitHub generated release notes when the input is blank
- add generated notes to alpha prereleases
- document suggested notes for the current v4 line

## Verification
- ruby YAML parse of .github/workflows/release.yml
- git diff --check
- local package zip smoke