### PR TITLE
Add allocation slider for redirect chances

### DIFF
--- a/assets/admin.css
+++ b/assets/admin.css
@@ -32,14 +32,78 @@
       .rrm-page .percent-sign { flex: 0 0 10px; margin-right: 5px; opacity: 0.7; }
       .rrm-page .remove-url { flex: 0 0 25px; background-color: #f44336; color: #fff; border: none; width: 25px; height: 25px; border-radius: 50%; display: flex; align-items: center; justify-content: center; cursor: pointer; font-size: 12px; padding: 0; line-height: 1; }
       .rrm-page .remove-url:hover { background-color: #e53935; }
-      .rrm-page .url-actions { display: flex; justify-content: space-between; align-items: center; margin-top: 10px; }
+      .rrm-page .url-actions { display: flex; justify-content: flex-start; align-items: center; gap: 8px; flex-wrap: wrap; margin-top: 10px; }
+      .rrm-page .url-actions .total-percentage { margin-left: auto; }
       .rrm-page .total-percentage { font-weight: bold; opacity: 0.8; }
       .rrm-page .percentage-sum { color: #008000; }
       .rrm-page .percentage-sum.error { color: #f44336; font-weight: bold; }
+      .rrm-page .rrm-allocation-editor { margin: 10px 0 8px; }
+      .rrm-page .rrm-allocation-editor.is-hidden { display: none; }
+      .rrm-page .rrm-allocation-label { margin: 0 0 6px; font-size: 0.86em; font-weight: 600; opacity: 0.72; }
+      .rrm-page .rrm-allocation-track {
+        position: relative;
+        height: 18px;
+        border: 1px solid rgba(128, 128, 128, 0.24);
+        border-radius: 4px;
+        background: rgba(128, 128, 128, 0.1);
+        overflow: visible;
+        touch-action: pan-y;
+      }
+      .rrm-page .rrm-allocation-segment {
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        min-width: 0;
+        overflow: hidden;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        color: #fff;
+        font-size: 0;
+        font-weight: 500;
+        line-height: 1;
+        white-space: nowrap;
+        opacity: 0.78;
+      }
+      .rrm-page .rrm-allocation-segment:first-child { border-radius: 3px 0 0 3px; }
+      .rrm-page .rrm-allocation-segment:last-of-type { border-radius: 0 3px 3px 0; }
+      .rrm-page .rrm-allocation-segment.is-tiny span { opacity: 0; }
+      .rrm-page .rrm-allocation-handle {
+        position: absolute;
+        top: 50%;
+        width: 10px;
+        height: 28px;
+        border: 1px solid rgba(255, 255, 255, 0.95);
+        border-radius: 999px;
+        background: #334155;
+        box-shadow: 0 1px 4px rgba(0, 0, 0, 0.24);
+        cursor: ew-resize;
+        touch-action: none;
+      }
+      .rrm-page .rrm-allocation-handle::after {
+        content: "";
+        position: absolute;
+        left: 50%;
+        top: 50%;
+        width: 44px;
+        height: 44px;
+        transform: translate(-50%, -50%);
+      }
+      .rrm-page .rrm-allocation-handle:focus {
+        outline: 3px solid rgba(0, 128, 255, 0.45);
+        outline-offset: 2px;
+      }
+      .rrm-page .rrm-allocation-meta { display: flex; gap: 8px; flex-wrap: wrap; margin-top: 6px; font-size: 0.82em; opacity: 0.75; }
+      .rrm-page .rrm-allocation-meta span { display: inline-flex; align-items: center; gap: 4px; }
+      .rrm-page .rrm-allocation-meta span::before { content: ""; width: 8px; height: 8px; border-radius: 50%; background: var(--rrm-segment-color); }
+      .rrm-page .rrm-allocation-empty {
+        font-size: 0.9em;
+        opacity: 0.72;
+      }
       /* Secondary buttons (Add URL, Pick..., Cancel). Translucent grays so the
          button blends with both Sleeky's light and dark themes - text uses
          `inherit` to pick up the surrounding admin chrome's foreground color. */
-      .rrm-page .button.button-secondary, .rrm-page .add-url, .rrm-page .pick-shortlink {
+      .rrm-page .button.button-secondary, .rrm-page .add-url, .rrm-page .pick-shortlink, .rrm-page .equal-split, .rrm-page .normalize-split {
         background-color: rgba(128, 128, 128, 0.18);
         color: inherit;
         border: 1px solid rgba(128, 128, 128, 0.5);
@@ -51,7 +115,7 @@
         font-weight: 500;
         transition: background-color 0.15s, border-color 0.15s;
       }
-      .rrm-page .button.button-secondary:hover, .rrm-page .add-url:hover, .rrm-page .pick-shortlink:hover {
+      .rrm-page .button.button-secondary:hover, .rrm-page .add-url:hover, .rrm-page .pick-shortlink:hover, .rrm-page .equal-split:hover, .rrm-page .normalize-split:hover {
         background-color: rgba(128, 128, 128, 0.3);
         border-color: rgba(128, 128, 128, 0.7);
       }
@@ -97,4 +161,6 @@
         .rrm-page .url-chance-row { flex-wrap: wrap; }
         .rrm-page .url-input { min-width: 200px; }
         .rrm-page .list-actions { flex-direction: column; align-items: flex-start; gap: 5px; }
+        .rrm-page .url-actions .total-percentage { flex-basis: 100%; margin-left: 0; }
+        .rrm-page .rrm-allocation-track { height: 22px; }
       }

--- a/assets/admin.js
+++ b/assets/admin.js
@@ -1,267 +1,524 @@
-      document.addEventListener('DOMContentLoaded', function() {
-        const form = document.getElementById('random-redirect-form');
-        if (!form) return;
+document.addEventListener('DOMContentLoaded', function() {
+  const form = document.getElementById('random-redirect-form');
+  if (!form) return;
 
-        // --- Shortlink picker bootstrap ---
-        let allShortlinks = [];
-        const bootstrapEl = document.getElementById('rrm-bootstrap');
-        if (bootstrapEl) {
-          try {
-            const data = JSON.parse(bootstrapEl.textContent);
-            if (Array.isArray(data.shortlinks)) allShortlinks = data.shortlinks;
-          } catch (e) { /* keep allShortlinks empty on parse failure */ }
-        }
+  const segmentColors = ['#3b82f6', '#10b981', '#f59e0b', '#8b5cf6', '#ef4444', '#06b6d4', '#6366f1', '#84cc16'];
 
-        const picker      = document.getElementById('rrm-picker');
-        const pickerInput = document.getElementById('rrm-picker-q');
-        const pickerList  = document.getElementById('rrm-picker-list');
-        const pickerCancel = document.getElementById('rrm-picker-cancel');
-        let pickerTarget = null;
+  // --- Shortlink picker bootstrap ---
+  let allShortlinks = [];
+  const bootstrapEl = document.getElementById('rrm-bootstrap');
+  if (bootstrapEl) {
+    try {
+      const data = JSON.parse(bootstrapEl.textContent);
+      if (Array.isArray(data.shortlinks)) allShortlinks = data.shortlinks;
+    } catch (e) { /* keep allShortlinks empty on parse failure */ }
+  }
 
-        // Sleeky's plugin emits <meta name="sleeky_theme" content="light|dark">
-        // when active. Tag the picker so its CSS picks the matching variant
-        // instead of forcing a white modal onto a dark page.
-        if (picker) {
-          const sleekyMeta = document.querySelector('meta[name="sleeky_theme"]');
-          if (sleekyMeta && sleekyMeta.getAttribute('content') === 'dark') {
-            picker.classList.add('rrm-dark');
-          }
-        }
+  const picker = document.getElementById('rrm-picker');
+  const pickerInput = document.getElementById('rrm-picker-q');
+  const pickerList = document.getElementById('rrm-picker-list');
+  const pickerCancel = document.getElementById('rrm-picker-cancel');
+  let pickerTarget = null;
 
-        function openPicker(targetInput) {
-          if (!picker) return;
-          pickerTarget = targetInput;
-          if (pickerInput) pickerInput.value = '';
-          renderPickerList('');
-          if (typeof picker.showModal === 'function') picker.showModal();
-          else picker.setAttribute('open', '');
-          if (pickerInput) setTimeout(() => pickerInput.focus(), 30);
-        }
+  if (picker) {
+    const sleekyMeta = document.querySelector('meta[name="sleeky_theme"]');
+    if (sleekyMeta && sleekyMeta.getAttribute('content') === 'dark') {
+      picker.classList.add('rrm-dark');
+    }
+  }
 
-        function closePicker() {
-          if (!picker) return;
-          if (typeof picker.close === 'function') picker.close();
-          else picker.removeAttribute('open');
-          pickerTarget = null;
-        }
+  function openPicker(targetInput) {
+    if (!picker) return;
+    pickerTarget = targetInput;
+    if (pickerInput) pickerInput.value = '';
+    renderPickerList('');
+    if (typeof picker.showModal === 'function') picker.showModal();
+    else picker.setAttribute('open', '');
+    if (pickerInput) setTimeout(() => pickerInput.focus(), 30);
+  }
 
-        function renderPickerList(query) {
-          if (!pickerList) return;
-          const q = (query || '').toLowerCase().trim();
-          const matches = (q === ''
-            ? allShortlinks
-            : allShortlinks.filter(l =>
-                (l.keyword || '').toLowerCase().includes(q) ||
-                (l.url     || '').toLowerCase().includes(q) ||
-                (l.title   || '').toLowerCase().includes(q)
-              )
-          ).slice(0, 200);
+  function closePicker() {
+    if (!picker) return;
+    if (typeof picker.close === 'function') picker.close();
+    else picker.removeAttribute('open');
+    pickerTarget = null;
+  }
 
-          pickerList.innerHTML = '';
-          if (matches.length === 0) {
-            const li = document.createElement('li');
-            li.innerHTML = '<em>No matches.</em>';
-            pickerList.appendChild(li);
-            return;
-          }
-          for (const link of matches) {
-            const li = document.createElement('li');
-            li.dataset.shorturl = link.shorturl || '';
-            const kw = document.createElement('strong');
-            kw.textContent = link.keyword;
-            li.appendChild(kw);
-            const url = document.createElement('span');
-            url.className = 'rrm-picker-url';
-            url.textContent = link.url || '';
-            li.appendChild(url);
-            if (link.title) {
-              const t = document.createElement('span');
-              t.className = 'rrm-picker-title';
-              t.textContent = link.title;
-              li.appendChild(t);
-            }
-            pickerList.appendChild(li);
-          }
-        }
+  function renderPickerList(query) {
+    if (!pickerList) return;
+    const q = (query || '').toLowerCase().trim();
+    const matches = (q === ''
+      ? allShortlinks
+      : allShortlinks.filter(l =>
+          (l.keyword || '').toLowerCase().includes(q) ||
+          (l.url || '').toLowerCase().includes(q) ||
+          (l.title || '').toLowerCase().includes(q)
+        )
+    ).slice(0, 200);
 
-        if (pickerInput) {
-          pickerInput.addEventListener('input', e => renderPickerList(e.target.value));
-          pickerInput.addEventListener('keydown', e => {
-            if (e.key === 'Enter') {
-              e.preventDefault();
-              const first = pickerList && pickerList.querySelector('li[data-shorturl]');
-              if (first) first.click();
-            } else if (e.key === 'Escape') {
-              closePicker();
-            }
-          });
-        }
-        if (pickerList) {
-          pickerList.addEventListener('click', e => {
-            const li = e.target.closest('li[data-shorturl]');
-            if (!li) return;
-            if (pickerTarget) {
-              pickerTarget.value = li.dataset.shorturl;
-              pickerTarget.dispatchEvent(new Event('input', { bubbles: true }));
-            }
-            closePicker();
-          });
-        }
-        if (pickerCancel) pickerCancel.addEventListener('click', closePicker);
+    pickerList.innerHTML = '';
+    if (matches.length === 0) {
+      const li = document.createElement('li');
+      li.innerHTML = '<em>No matches.</em>';
+      pickerList.appendChild(li);
+      return;
+    }
+    for (const link of matches) {
+      const li = document.createElement('li');
+      li.dataset.shorturl = link.shorturl || '';
+      const kw = document.createElement('strong');
+      kw.textContent = link.keyword;
+      li.appendChild(kw);
+      const url = document.createElement('span');
+      url.className = 'rrm-picker-url';
+      url.textContent = link.url || '';
+      li.appendChild(url);
+      if (link.title) {
+        const t = document.createElement('span');
+        t.className = 'rrm-picker-title';
+        t.textContent = link.title;
+        li.appendChild(t);
+      }
+      pickerList.appendChild(li);
+    }
+  }
 
-        // --- Event Delegation ---
-        form.addEventListener('click', function(event) {
-          // Add URL button
-          if (event.target.classList.contains('add-url')) {
-            event.preventDefault();
-            const container = event.target.closest('.redirect-list-col, .settings-group').querySelector('.url-chances-container');
-            if (container) {
-              addNewUrlRow(container);
-            }
-          }
-          // Remove URL button
-          else if (event.target.classList.contains('remove-url')) {
-            event.preventDefault();
-            const row = event.target.closest('.url-chance-row');
-            const container = row.closest('.url-chances-container');
-            removeUrlRow(row, container);
-          }
-          // Pick existing shortlink
-          else if (event.target.classList.contains('pick-shortlink')) {
-            event.preventDefault();
-            const row = event.target.closest('.url-chance-row');
-            const urlInput = row && row.querySelector('.url-input');
-            if (urlInput) openPicker(urlInput);
-          }
-        });
+  if (pickerInput) {
+    pickerInput.addEventListener('input', e => renderPickerList(e.target.value));
+    pickerInput.addEventListener('keydown', e => {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        const first = pickerList && pickerList.querySelector('li[data-shorturl]');
+        if (first) first.click();
+      } else if (e.key === 'Escape') {
+        closePicker();
+      }
+    });
+  }
+  if (pickerList) {
+    pickerList.addEventListener('click', e => {
+      const li = e.target.closest('li[data-shorturl]');
+      if (!li) return;
+      if (pickerTarget) {
+        pickerTarget.value = li.dataset.shorturl;
+        pickerTarget.dispatchEvent(new Event('input', { bubbles: true }));
+      }
+      closePicker();
+    });
+  }
+  if (pickerCancel) pickerCancel.addEventListener('click', closePicker);
 
-        form.addEventListener('input', function(event) {
-          // Chance input changes
-          if (event.target.classList.contains('chance-input')) {
-            const container = event.target.closest('.url-chances-container');
-            if (container) {
-              updatePercentageSum(container);
-            }
-          }
-          // Keyword input changes (update header display)
-          else if (event.target.classList.contains('keyword-input')) {
-             const listSettings = event.target.closest('.redirect-list-settings');
-             if (listSettings && !listSettings.classList.contains('add-new-list')) {
-                const displaySpan = listSettings.querySelector('.keyword-display');
-                if(displaySpan) {
-                    displaySpan.textContent = event.target.value;
-                }
-             }
-          }
-          // New-list keyword toggles the required-state of its URL rows.
-          if (event.target.id === 'new_list_keyword') {
-            syncNewListRequired();
-          }
-        });
+  form.addEventListener('click', function(event) {
+    const addButton = event.target.closest('.add-url');
+    const removeButton = event.target.closest('.remove-url');
+    const pickButton = event.target.closest('.pick-shortlink');
+    const equalButton = event.target.closest('.equal-split');
+    const normalizeButton = event.target.closest('.normalize-split');
 
-        // --- Initialization ---
-        // Calculate initial percentage sums for all containers
-        document.querySelectorAll('.url-chances-container').forEach(container => {
-          updatePercentageSum(container);
-        });
-        // Apply the initial required-state to the new-list URL rows so a
-        // pre-filled keyword (e.g. after a server-side validation bounce)
-        // gets the required attribute right away.
-        syncNewListRequired();
-      });
+    if (addButton) {
+      event.preventDefault();
+      const container = addButton.closest('.redirect-list-col, .settings-group').querySelector('.url-chances-container');
+      if (container) addNewUrlRow(container);
+    } else if (removeButton) {
+      event.preventDefault();
+      const row = removeButton.closest('.url-chance-row');
+      if (!row) return;
+      const container = row.closest('.url-chances-container');
+      if (container) removeUrlRow(row, container);
+    } else if (pickButton) {
+      event.preventDefault();
+      const row = pickButton.closest('.url-chance-row');
+      const urlInput = row && row.querySelector('.url-input');
+      if (urlInput) openPicker(urlInput);
+    } else if (equalButton) {
+      event.preventDefault();
+      const container = findListContainer(equalButton);
+      if (container) {
+        setEqualSplit(container);
+        renderAllocationEditor(container);
+      }
+    } else if (normalizeButton) {
+      event.preventDefault();
+      const container = findListContainer(normalizeButton);
+      if (container) {
+        normalizeSplit(container);
+        renderAllocationEditor(container);
+      }
+    }
+  });
 
-      function addNewUrlRow(container) {
-        const template = container.querySelector('.template');
-        if (!template) return;
-
-        const newRow = template.cloneNode(true);
-        newRow.style.display = 'flex';
-        newRow.classList.remove('template');
-
-        const urlInput = newRow.querySelector('.url-input');
-        const chanceInput = newRow.querySelector('.chance-input');
-        if (urlInput) {
-            urlInput.value = '';
-            // Existing-list rows must always be required so the user
-            // can't silently submit an empty URL. New-list rows track
-            // the keyword field via syncNewListRequired() below.
-            const isNewListRow = (urlInput.name || '').startsWith('new_list_urls');
-            if (isNewListRow) {
-                urlInput.removeAttribute('required');
-            } else {
-                urlInput.setAttribute('required', '');
-            }
-        }
-        if (chanceInput) chanceInput.value = '';
-
-        // Enable inputs (template inputs might be disabled)
-        newRow.querySelectorAll('input').forEach(input => input.disabled = false);
-
-        // Insert before the template
-        container.insertBefore(newRow, template);
-
+  form.addEventListener('input', function(event) {
+    if (event.target.classList.contains('chance-input')) {
+      const container = event.target.closest('.url-chances-container');
+      if (container) {
         updatePercentageSum(container);
-        // Newly added new-list rows might still need to flip to required
-        // if the user has already typed a keyword.
-        syncNewListRequired();
-        if (urlInput) urlInput.focus();
+        renderAllocationEditor(container);
       }
-
-      // Make the New-Redirect-List section's URL inputs required only
-      // when the user has actually typed a new keyword. Otherwise the
-      // empty starter row in that section would block every save.
-      function syncNewListRequired() {
-        const kwInput = document.getElementById('new_list_keyword');
-        if (!kwInput) return;
-        const hasKeyword = kwInput.value.trim() !== '';
-        document
-          .querySelectorAll('input[name="new_list_urls[]"]')
-          .forEach((input) => {
-            const row = input.closest('.url-chance-row');
-            if (row && row.classList.contains('template')) return;
-            if (hasKeyword) input.setAttribute('required', '');
-            else input.removeAttribute('required');
-          });
+    } else if (event.target.classList.contains('keyword-input')) {
+      const listSettings = event.target.closest('.redirect-list-settings');
+      if (listSettings && !listSettings.classList.contains('add-new-list')) {
+        const displaySpan = listSettings.querySelector('.keyword-display');
+        if (displaySpan) displaySpan.textContent = event.target.value;
       }
+    }
 
-      function removeUrlRow(row, container) {
-        // Count visible rows excluding the template
-        const visibleRows = Array.from(container.querySelectorAll('.url-chance-row:not(.template)'));
+    if (event.target.id === 'new_list_keyword') {
+      syncNewListRequired();
+    }
+  });
 
-        if (visibleRows.length > 1) {
-          row.remove();
-          updatePercentageSum(container); // Update sum after removing
-        } else {
-          alert('You must have at least one URL in the list.');
-        }
+  document.querySelectorAll('.url-chances-container').forEach(container => {
+    updatePercentageSum(container);
+    renderAllocationEditor(container);
+  });
+  syncNewListRequired();
+
+  function addNewUrlRow(container) {
+    const template = container.querySelector('.template');
+    if (!template) return;
+
+    const newRow = template.cloneNode(true);
+    newRow.style.display = 'flex';
+    newRow.classList.remove('template');
+
+    const urlInput = newRow.querySelector('.url-input');
+    const chanceInput = newRow.querySelector('.chance-input');
+    if (urlInput) {
+      urlInput.value = '';
+      const isNewListRow = (urlInput.name || '').startsWith('new_list_urls');
+      if (isNewListRow) urlInput.removeAttribute('required');
+      else urlInput.setAttribute('required', '');
+    }
+    if (chanceInput) chanceInput.value = '';
+
+    newRow.querySelectorAll('input').forEach(input => input.disabled = false);
+    container.insertBefore(newRow, template);
+
+    updatePercentageSum(container);
+    renderAllocationEditor(container);
+    syncNewListRequired();
+    if (urlInput) urlInput.focus();
+  }
+
+  function syncNewListRequired() {
+    const kwInput = document.getElementById('new_list_keyword');
+    if (!kwInput) return;
+    const hasKeyword = kwInput.value.trim() !== '';
+    document
+      .querySelectorAll('input[name="new_list_urls[]"]')
+      .forEach(input => {
+        const row = input.closest('.url-chance-row');
+        if (row && row.classList.contains('template')) return;
+        if (hasKeyword) input.setAttribute('required', '');
+        else input.removeAttribute('required');
+      });
+  }
+
+  function removeUrlRow(row, container) {
+    const visibleRows = Array.from(container.querySelectorAll('.url-chance-row:not(.template)'));
+
+    if (visibleRows.length > 1) {
+      row.remove();
+      updatePercentageSum(container);
+      renderAllocationEditor(container);
+    } else {
+      alert('You must have at least one URL in the list.');
+    }
+  }
+
+  function findListContainer(element) {
+    const scope = element.closest('.redirect-list-col, .settings-group');
+    return scope && scope.querySelector('.url-chances-container');
+  }
+
+  function getChanceInputs(container) {
+    return Array.from(container.querySelectorAll('.url-chance-row:not(.template) .chance-input'));
+  }
+
+  function getChanceValues(container) {
+    return getChanceInputs(container).map(input => {
+      const value = parseFloat(input.value);
+      return Number.isFinite(value) && value > 0 ? value : 0;
+    });
+  }
+
+  function roundChance(value) {
+    const finiteValue = Number.isFinite(value) ? value : 0;
+    return Math.round(finiteValue * 10) / 10;
+  }
+
+  function formatChance(value) {
+    const rounded = roundChance(value);
+    return Number.isInteger(rounded) ? String(rounded) : rounded.toFixed(1);
+  }
+
+  function valuesToNormalized(values) {
+    const safeValues = values.map(value => Number.isFinite(value) ? Math.max(0, value) : 0);
+    const total = safeValues.reduce((sum, value) => sum + value, 0);
+    if (values.length === 0) return [];
+    if (total <= 0) return equalValues(values.length);
+
+    let running = 0;
+    return safeValues.map((value, index) => {
+      if (index === safeValues.length - 1) {
+        return roundChance(Math.max(0, 100 - running));
       }
+      const next = roundChance((value / total) * 100);
+      running = roundChance(running + next);
+      return next;
+    });
+  }
 
-      function updatePercentageSum(container) {
-        const inputs = Array.from(container.querySelectorAll('.url-chance-row:not(.template) .chance-input'));
-        let sum = 0;
-        let hasNonEmptyChance = false;
+  function equalValues(count) {
+    if (count <= 0) return [];
+    const base = Math.floor((1000 / count)) / 10;
+    const values = Array(count).fill(base);
+    const used = roundChance(base * count);
+    values[count - 1] = roundChance(values[count - 1] + (100 - used));
+    return values;
+  }
 
-        inputs.forEach(input => {
-          const value = parseFloat(input.value);
-          if (!isNaN(value) && value > 0) { // Only sum positive values
-            sum += value;
-          }
-          if (input.value.trim() !== '') {
-            hasNonEmptyChance = true;
-          }
-        });
+  function applyChanceValues(container, values) {
+    getChanceInputs(container).forEach((input, index) => {
+      input.value = formatChance(values[index] || 0);
+      input.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+    updatePercentageSum(container);
+  }
 
-        // Find the sum display element relative to the container
-        const sumElement = container.closest('.redirect-list-col, .settings-group').querySelector('.percentage-sum');
-        if (!sumElement) return;
+  function setEqualSplit(container) {
+    applyChanceValues(container, equalValues(getChanceInputs(container).length));
+  }
 
-        sumElement.textContent = sum.toFixed(1); // Use toFixed for consistent decimal display
+  function normalizeSplit(container) {
+    applyChanceValues(container, valuesToNormalized(getChanceValues(container)));
+  }
 
-        // Add error class if sum is positive but not close to 100, or if any chance was entered
-        const tolerance = 0.01; // Allow for floating point inaccuracies
-        if (hasNonEmptyChance && Math.abs(sum - 100) > tolerance) {
-           sumElement.classList.add('error');
-        } else {
-           sumElement.classList.remove('error');
-        }
+  function valuesToBoundaries(values) {
+    const normalized = valuesToNormalized(values);
+    const boundaries = [];
+    let running = 0;
+    normalized.slice(0, -1).forEach(value => {
+      running = roundChance(running + value);
+      boundaries.push(running);
+    });
+    return boundaries;
+  }
+
+  function boundariesToValues(boundaries) {
+    const points = [0].concat(boundaries, 100);
+    const values = [];
+    for (let i = 1; i < points.length; i++) {
+      values.push(roundChance(points[i] - points[i - 1]));
+    }
+    return values;
+  }
+
+  function renderAllocationEditor(container, focusHandleIndex) {
+    const editor = container.parentElement.querySelector('.rrm-allocation-editor');
+    if (!editor) return;
+
+    const inputs = getChanceInputs(container);
+    editor.innerHTML = '';
+    editor.classList.toggle('is-hidden', inputs.length === 0);
+
+    if (inputs.length === 0) return;
+    if (inputs.length === 1) {
+      const empty = document.createElement('div');
+      empty.className = 'rrm-allocation-empty';
+      empty.textContent = 'Single URL gets 100%.';
+      editor.appendChild(empty);
+      return;
+    }
+
+    const values = valuesToNormalized(getChanceValues(container));
+    const boundaries = valuesToBoundaries(values);
+    const label = document.createElement('div');
+    label.className = 'rrm-allocation-label';
+    label.textContent = 'Traffic split';
+    editor.appendChild(label);
+
+    const track = document.createElement('div');
+    track.className = 'rrm-allocation-track';
+
+    let left = 0;
+    values.forEach((value, index) => {
+      const segment = document.createElement('div');
+      segment.className = 'rrm-allocation-segment';
+      if (value < 6) segment.classList.add('is-tiny');
+      segment.style.left = left + '%';
+      segment.style.width = value + '%';
+      segment.style.backgroundColor = segmentColors[index % segmentColors.length];
+
+      const label = document.createElement('span');
+      label.textContent = formatChance(value) + '%';
+      segment.appendChild(label);
+      track.appendChild(segment);
+      left = roundChance(left + value);
+    });
+
+    boundaries.forEach((boundary, index) => {
+      const handle = document.createElement('button');
+      handle.type = 'button';
+      handle.className = 'rrm-allocation-handle';
+      handle.style.left = boundary + '%';
+      handle.style.transform = 'translate(-50%, -50%) translateY(' + handleVisualOffset(boundaries, index) + 'px)';
+      handle.style.zIndex = String(10 + index);
+      handle.dataset.boundaryIndex = String(index);
+      handle.setAttribute('role', 'slider');
+      handle.setAttribute('aria-orientation', 'horizontal');
+      handle.setAttribute('aria-valuemin', formatChance(index === 0 ? 0 : boundaries[index - 1]));
+      handle.setAttribute('aria-valuemax', formatChance(index === boundaries.length - 1 ? 100 : boundaries[index + 1]));
+      handle.setAttribute('aria-valuenow', formatChance(boundary));
+      handle.setAttribute('aria-valuetext', 'Boundary at ' + formatChance(boundary) + ' percent');
+      handle.setAttribute('aria-label', 'Adjust split between URL ' + (index + 1) + ' and URL ' + (index + 2));
+      handle.addEventListener('pointerdown', event => beginHandleDrag(event, track, container, index, boundaries));
+      handle.addEventListener('keydown', event => handleBoundaryKey(event, container, index, boundaries));
+      track.appendChild(handle);
+    });
+
+    editor.appendChild(track);
+
+    const meta = document.createElement('div');
+    meta.className = 'rrm-allocation-meta';
+    values.forEach((value, index) => {
+      const item = document.createElement('span');
+      item.style.setProperty('--rrm-segment-color', segmentColors[index % segmentColors.length]);
+      item.textContent = 'URL ' + (index + 1) + ': ' + formatChance(value) + '%';
+      meta.appendChild(item);
+    });
+    editor.appendChild(meta);
+
+    if (typeof focusHandleIndex === 'number') {
+      const handle = track.querySelector('.rrm-allocation-handle[data-boundary-index="' + focusHandleIndex + '"]');
+      if (handle) handle.focus();
+    }
+  }
+
+  function handleVisualOffset(boundaries, index) {
+    let overlapRank = 0;
+    for (let i = 0; i < index; i++) {
+      if (Math.abs(boundaries[i] - boundaries[index]) < 0.1) overlapRank++;
+    }
+    return overlapRank * 10;
+  }
+
+  function updateAllocationTrack(track, values, boundaries) {
+    const segments = Array.from(track.querySelectorAll('.rrm-allocation-segment'));
+    const handles = Array.from(track.querySelectorAll('.rrm-allocation-handle'));
+    const metaItems = Array.from(track.parentElement.querySelectorAll('.rrm-allocation-meta span'));
+    let left = 0;
+
+    values.forEach((value, index) => {
+      const segment = segments[index];
+      if (!segment) return;
+      segment.classList.toggle('is-tiny', value < 6);
+      segment.style.left = left + '%';
+      segment.style.width = value + '%';
+      const label = segment.querySelector('span');
+      if (label) label.textContent = formatChance(value) + '%';
+      if (metaItems[index]) {
+        metaItems[index].textContent = 'URL ' + (index + 1) + ': ' + formatChance(value) + '%';
       }
+      left = roundChance(left + value);
+    });
+
+    boundaries.forEach((boundary, index) => {
+      const handle = handles[index];
+      if (!handle) return;
+      handle.style.left = boundary + '%';
+      handle.style.transform = 'translate(-50%, -50%) translateY(' + handleVisualOffset(boundaries, index) + 'px)';
+      handle.setAttribute('aria-valuemin', formatChance(index === 0 ? 0 : boundaries[index - 1]));
+      handle.setAttribute('aria-valuemax', formatChance(index === boundaries.length - 1 ? 100 : boundaries[index + 1]));
+      handle.setAttribute('aria-valuenow', formatChance(boundary));
+      handle.setAttribute('aria-valuetext', 'Boundary at ' + formatChance(boundary) + ' percent');
+    });
+  }
+
+  function clampBoundary(value, boundaries, index) {
+    const minGap = 0;
+    const min = index === 0 ? 0 : boundaries[index - 1] + minGap;
+    const max = index === boundaries.length - 1 ? 100 : boundaries[index + 1] - minGap;
+    return Math.min(max, Math.max(min, roundChance(value)));
+  }
+
+  function applyBoundary(container, boundaries, index, value, focusHandleIndex) {
+    const nextBoundaries = boundaries.slice();
+    nextBoundaries[index] = clampBoundary(value, nextBoundaries, index);
+    applyChanceValues(container, boundariesToValues(nextBoundaries));
+    renderAllocationEditor(container, focusHandleIndex);
+    return nextBoundaries;
+  }
+
+  function boundaryValueFromPointer(event, track) {
+    const rect = track.getBoundingClientRect();
+    if (rect.width <= 0) return 0;
+    return ((event.clientX - rect.left) / rect.width) * 100;
+  }
+
+  function beginHandleDrag(event, track, container, index, boundaries) {
+    event.preventDefault();
+    const handle = event.currentTarget;
+    let dragBoundaries = boundaries.slice();
+    if (handle.setPointerCapture) handle.setPointerCapture(event.pointerId);
+
+    const move = moveEvent => {
+      dragBoundaries[index] = clampBoundary(boundaryValueFromPointer(moveEvent, track), dragBoundaries, index);
+      const values = boundariesToValues(dragBoundaries);
+      applyChanceValues(container, values);
+      updateAllocationTrack(track, values, dragBoundaries);
+    };
+    const stop = stopEvent => {
+      if (handle.releasePointerCapture) handle.releasePointerCapture(stopEvent.pointerId);
+      window.removeEventListener('pointermove', move);
+      window.removeEventListener('pointerup', stop);
+      window.removeEventListener('pointercancel', stop);
+      renderAllocationEditor(container);
+    };
+
+    window.addEventListener('pointermove', move);
+    window.addEventListener('pointerup', stop);
+    window.addEventListener('pointercancel', stop);
+    move(event);
+  }
+
+  function handleBoundaryKey(event, container, index, boundaries) {
+    const current = boundaries[index];
+    let next = current;
+
+    if (event.key === 'ArrowRight' || event.key === 'ArrowUp') next = current + 1;
+    else if (event.key === 'ArrowLeft' || event.key === 'ArrowDown') next = current - 1;
+    else if (event.key === 'PageUp') next = current + 10;
+    else if (event.key === 'PageDown') next = current - 10;
+    else if (event.key === 'Home') next = index === 0 ? 0 : boundaries[index - 1];
+    else if (event.key === 'End') next = index === boundaries.length - 1 ? 100 : boundaries[index + 1];
+    else return;
+
+    event.preventDefault();
+    applyBoundary(container, boundaries, index, next, index);
+  }
+
+  function updatePercentageSum(container) {
+    const inputs = getChanceInputs(container);
+    let sum = 0;
+    let hasNonEmptyChance = false;
+
+    inputs.forEach(input => {
+      const value = parseFloat(input.value);
+      if (Number.isFinite(value) && value > 0) sum += value;
+      if (input.value.trim() !== '') hasNonEmptyChance = true;
+    });
+
+    const sumElement = container.closest('.redirect-list-col, .settings-group').querySelector('.percentage-sum');
+    if (!sumElement) return;
+
+    sumElement.textContent = sum.toFixed(1);
+
+    const tolerance = 0.01;
+    if (hasNonEmptyChance && Math.abs(sum - 100) > tolerance) {
+      sumElement.classList.add('error');
+    } else {
+      sumElement.classList.remove('error');
+    }
+  }
+});

--- a/includes/class-random-redirect-manager.php
+++ b/includes/class-random-redirect-manager.php
@@ -334,8 +334,11 @@ HTML;
 
         echo <<<HTML
                 </div> <!-- .url-chances-container -->
+                <div class="rrm-allocation-editor" aria-label="Traffic split editor"></div>
                 <div class="url-actions">
                   <button type="button" class="add-url button button-secondary">Add URL</button>
+                  <button type="button" class="equal-split button button-secondary">Equal split</button>
+                  <button type="button" class="normalize-split button button-secondary" title="Scale current chance values so they add up to 100%, while keeping the same relative split.">Scale to 100%</button>
                   <div class="total-percentage">
                     Total: <span class="percentage-sum">0</span>%
                   </div>
@@ -382,8 +385,11 @@ HTML;
 
         echo <<<HTML
         </div> <!-- .url-chances-container -->
+        <div class="rrm-allocation-editor" aria-label="Traffic split editor"></div>
         <div class="url-actions">
           <button type="button" class="add-url button button-secondary">Add URL</button>
+          <button type="button" class="equal-split button button-secondary">Equal split</button>
+          <button type="button" class="normalize-split button button-secondary" title="Scale current chance values so they add up to 100%, while keeping the same relative split.">Scale to 100%</button>
           <div class="total-percentage">
             Total: <span class="percentage-sum">0</span>%
           </div>


### PR DESCRIPTION
## Summary
- Add a segmented traffic split editor for redirect chance percentages
- Add Equal split and Scale to 100% controls while keeping existing numeric inputs synced
- Support pointer drag, keyboard slider controls, live legends, and add/remove row rebuilds

## Verification
- node --check assets/admin.js
- php -l plugin.php
- php -l includes/bootstrap.php
- php -l includes/class-random-redirect-manager.php
- Manual check in local YOURLS Docker admin page

## Notes
- phpunit is installed, but the local run is blocked until the YOURLS plugin test-suite is checked out at test-suite/src/bootstrap.php.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added interactive traffic allocation editor with visual segment display
  * Enabled drag-and-drop adjustment of URL traffic split using keyboard and mouse controls
  * Added "Equal Split" button to distribute traffic evenly across URLs
  * Added "Normalize" button to automatically adjust allocation values to sum to 100%

<!-- end of auto-generated comment: release notes by coderabbit.ai -->